### PR TITLE
Fixed game not building on Linux

### DIFF
--- a/src/game/client/client_ofd.vpc
+++ b/src/game/client/client_ofd.vpc
@@ -32,7 +32,7 @@ $Project "Client (OFD)"
 			$File	"of\c_of_trigger_jump.h"
 			$File	"of\c_of_trigger_jump.cpp"
 			$File	"of\of_discordrpc.cpp"
-			$File	"of\of_discordrpc.h"			
+			$File	"of\of_discordrpc.h"
 			$File   "of\of_imagecoloredhudpanel.cpp"
 			$File   "of\of_imagecoloredhudpanel.h"
 			$File	"$SRCDIR\game\shared\of\of_trigger_jump_shared.cpp"
@@ -45,23 +45,23 @@ $Project "Client (OFD)"
 			$File	"$SRCDIR\game\shared\of\of_weapon_bfg.cpp"
 			$File	"$SRCDIR\game\shared\of\of_weapon_bfg.h"
 			$File	"$SRCDIR\game\shared\of\of_projectile_bfg.cpp"
-			$File	"$SRCDIR\game\shared\of\of_projectile_bfg.h"		
+			$File	"$SRCDIR\game\shared\of\of_projectile_bfg.h"
 			$File	"of\of_hud_account.cpp"
 			$File	"of\of_hud_account.h"
 			$File	"of\c_of_dropped_weapon.cpp"
 			$File	"of\c_of_dropped_powerup.cpp"
 			$File	"of\c_entity_weapon_spawner.cpp"
-            $File	"of\c_entity_condpowerup.cpp"			
+            $File	"of\c_entity_condpowerup.cpp"
 			$File	"of\c_weapon_grapple.cpp"
-			$File	"of\c_weapon_grapple.h"		
+			$File	"of\c_weapon_grapple.h"
 			$File	"of\of_hud_dom.cpp"
-			$File	"of\of_hud_dom.h"			
+			$File	"of\of_hud_dom.h"
 			$File	"of\of_hud_tdm.cpp"
 			$File	"of\of_hud_tdm.h"
 			$File	"of\of_hud_kills.cpp"
-			$File	"of\of_hud_kills.h"	
+			$File	"of\of_hud_kills.h"
 			$File	"of\of_hud_powerups.cpp"
-			$File	"of\of_hud_powerups.h"	
+			$File	"of\of_hud_powerups.h"
 			$File	"tf\tf_hud_shieldcharge.cpp"
 			$File	"tf\tf_hud_swapweapons.cpp"
 			$File	"tf\tf_hud_lungemeter.cpp"
@@ -71,7 +71,7 @@ $Project "Client (OFD)"
 			$File	"$SRCDIR\game\shared\of\gamemounter.h"
 			$File	"of\vgui\of_loadout.cpp"
 			$File	"of\vgui\of_loadout.h"
-			$File	"of\vgui\of_imageprogressbar.cpp"			
+			$File	"of\vgui\of_imageprogressbar.cpp"
 			$File	"of\vgui\of_imageprogressbar.h"
 			$File	"of\c_of_music_player.cpp"
 			$File	"of\c_of_music_player.h"
@@ -79,10 +79,14 @@ $Project "Client (OFD)"
 			$File	"of\fmod_manager.h"
 			$File	"$SRCDIR\game\shared\of\of_announcer_system.cpp"
 			$File	"$SRCDIR\game\shared\of\of_announcer_system.h"
-			
+
             $File "$SRCDIR\game\shared\of\engine_patch.h"
 
             $File "$SRCDIR\game\shared\of\engine_patch.cpp"
+
+            $File "$SRCDIR\game\shared\of\util\os_utils.h"
+
+            $File "$SRCDIR\game\shared\of\util\os_utils.cpp"
             {
                 $Configuration
                 {
@@ -93,7 +97,7 @@ $Project "Client (OFD)"
                 }
             }
 		}
-		
+
 		$File	"$SRCDIR\game\shared\basecombatweapon_shared.h"
 		$File	"c_team_objectiveresource.cpp"
 		$File	"c_team_objectiveresource.h"
@@ -114,9 +118,9 @@ $Project "Client (OFD)"
 		$File	"worldlight.cpp"
 		$File	"worldlight.h"
 		$File	"hud_base_account.h"
-		
+
 		-$File	"$SRCDIR\game\shared\weapon_parse_default.cpp"
-		
+
 		$Folder "NextBot"
 		{
 			$File	"NextBot\c_NextBot.cpp"
@@ -130,7 +134,7 @@ $Project "Client (OFD)"
 		$Folder	"TF"
 		{
 			$File	"$SRCDIR\game\shared\tf\achievements_tf.cpp"
-			$File	"$SRCDIR\game\shared\tf\baseobject_shared.cpp"				
+			$File	"$SRCDIR\game\shared\tf\baseobject_shared.cpp"
 			$File	"tf\c_baseobject.cpp"
 			$File	"tf\c_baseobject.h"
 			$File	"tf\c_func_respawnroom.cpp"
@@ -295,7 +299,7 @@ $Project "Client (OFD)"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_flamethrower.cpp"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_flamethrower.h"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_flag.cpp"
-				$File	"$SRCDIR\game\shared\tf\tf_weapon_flag.h"				
+				$File	"$SRCDIR\game\shared\tf\tf_weapon_flag.h"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_grenade_pipebomb.cpp"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_grenade_pipebomb.h"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_grenadelauncher.cpp"
@@ -333,7 +337,7 @@ $Project "Client (OFD)"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_sniperrifle.cpp"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_sniperrifle.h"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_railgun.cpp"
-				$File	"$SRCDIR\game\shared\tf\tf_weapon_railgun.h"				
+				$File	"$SRCDIR\game\shared\tf\tf_weapon_railgun.h"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_syringegun.cpp"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_syringegun.h"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_wrench.cpp"
@@ -407,7 +411,7 @@ $Project "Client (OFD)"
 			$File	"$SRCDIR\game\shared\weapon_ifmbasecamera.h"
 			$File	"$SRCDIR\game\shared\weapon_ifmsteadycam.cpp"
 		}
-		
+
 
 		$Folder	"HL2 DLL"
 		{
@@ -472,7 +476,7 @@ $Project "Client (OFD)"
 			$File	"hl2\hud_credits.cpp"
 			$File	"$SRCDIR\game\shared\hl2\survival_gamerules.cpp"
 			$File	"episodic\c_npc_puppet.cpp"
-			
+
 		}
 	}
 	$Folder "Link Libraries"

--- a/src/game/server/server_ofd.vpc
+++ b/src/game/server/server_ofd.vpc
@@ -31,7 +31,7 @@ $Project "Server (OFD)"
 		$Folder	"OPENFORTRESS DLL"
 		{
 			$File	"of\entity_condpowerup.cpp"
-			$File	"of\entity_condpowerup.h"			
+			$File	"of\entity_condpowerup.h"
 			$File	"of\entity_weapon_spawner.cpp"
 			$File	"of\entity_weapon_spawner.h"
 			$File	"of\of_trigger_jump.h"
@@ -39,13 +39,13 @@ $Project "Server (OFD)"
 			$File	"$SRCDIR\game\shared\of\of_trigger_jump_shared.cpp"
 			$File	"of\hl1_ents.h"
 			$File	"of\hl1_ents.cpp"
-			$File	"of\item_healthkit_tiny.cpp"	
+			$File	"of\item_healthkit_tiny.cpp"
 			$File	"of\item_healthkit_mega.cpp"
 			$File	"of\logic_eventlistener.cpp"
 			$File	"of\datadesc_mod.cpp"
 			$File	"of\datadesc_mod.h"
 			$File	"of\matchers.h"
-			$File	"$SRCDIR\game\shared\of\of_weapon_flaregun.cpp"			
+			$File	"$SRCDIR\game\shared\of\of_weapon_flaregun.cpp"
 			$File	"$SRCDIR\game\shared\of\of_weapon_physcannon.cpp"
 			$File	"$SRCDIR\game\shared\of\of_weapon_physcannon.h"
 			$File	"$SRCDIR\game\shared\of\of_weapon_tripmine.cpp"
@@ -54,7 +54,7 @@ $Project "Server (OFD)"
 			$File	"$SRCDIR\game\shared\of\of_weapon_bfg.cpp"
 			$File	"$SRCDIR\game\shared\of\of_weapon_bfg.h"
 			$File	"$SRCDIR\game\shared\of\of_projectile_bfg.cpp"
-			$File	"$SRCDIR\game\shared\of\of_projectile_bfg.h"	
+			$File	"$SRCDIR\game\shared\of\of_projectile_bfg.h"
 			$File	"of\of_dropped_weapon.cpp"
 			$File	"of\of_dropped_weapon.h"
 			$File	"of\of_dropped_powerup.cpp"
@@ -70,17 +70,21 @@ $Project "Server (OFD)"
 			$File	"of\of_tfcgrenade_frag.cpp"
 			$File	"of\of_tfcgrenade_frag.h"
 			$File	"tf\tf_weapon_grapple.cpp"
-			$File	"tf\tf_weapon_grapple.h"		
+			$File	"tf\tf_weapon_grapple.h"
 			$File	"of\func_bomb_target.cpp"
 			$File	"of\func_bomb_target.h"
 			$File	"of\of_music_player.cpp"
-			$File	"of\of_music_player.h"		
+			$File	"of\of_music_player.h"
 			$File	"$SRCDIR\game\shared\of\of_announcer_system.cpp"
 			$File	"$SRCDIR\game\shared\of\of_announcer_system.h"
-			
+
             $File "$SRCDIR\game\shared\of\engine_patch.h"
 
             $File "$SRCDIR\game\shared\of\engine_patch.cpp"
+
+            $File "$SRCDIR\game\shared\of\util\os_utils.h"
+
+            $File "$SRCDIR\game\shared\of\util\os_utils.cpp"
             {
                 $Configuration
                 {
@@ -92,7 +96,7 @@ $Project "Server (OFD)"
             }
 
 		}
-		
+
 		$File	"ai_relationship.cpp"
 		$File	"basegrenade_concussion.cpp"
 		$File	"basegrenade_contact.cpp"
@@ -125,10 +129,10 @@ $Project "Server (OFD)"
 		$File	"$SRCDIR\game\shared\touchlink.h"
 		$File	"trigger_area_capture.cpp"
 		$File	"trigger_area_capture.h"
-		
+
 		$File	"point_entity_finder.cpp"
 		$File	"skyboxswapper.cpp"
-		
+
 		$File	"ai_eventresponse.cpp"
 		$File	"ai_eventresponse.h"
 		$File	"h_cycler.cpp"
@@ -136,7 +140,7 @@ $Project "Server (OFD)"
 		$File	"logic_achievement.cpp"
 		$File	"vehicle_choreo_generic.cpp"
 		$File	"$SRCDIR\game\shared\vehicle_choreo_generic_shared.h"
-		
+
 		$Folder "NextBot"
 		{
 			$File	"NextBot\NextBot.cpp"
@@ -170,7 +174,7 @@ $Project "Server (OFD)"
 			$File	"NextBot\simple_bot.h"
 			$File	"NextBot\NavMeshEntities\func_nav_prerequisite.cpp"
 			$File	"NextBot\NavMeshEntities\func_nav_prerequisite.h"
-			
+
 			$Folder "Path"
 			{
 				$File "NextBot\Path\NextBotChasePath.cpp"
@@ -181,7 +185,7 @@ $Project "Server (OFD)"
 				$File "NextBot\Path\NextBotPathFollow.h"
 				$File "NextBot\Path\NextBotRetreatPath.h"
 			}
-			
+
 			$Folder "Player"
 			{
 				$File "NextBot\Player\NextBotPlayer.cpp"
@@ -191,7 +195,7 @@ $Project "Server (OFD)"
 				$File "NextBot\Player\NextBotPlayerLocomotion.cpp"
 				$File "NextBot\Player\NextBotPlayerLocomotion.h"
 			}
-		}	
+		}
 
 		$Folder	"TF"
 		{
@@ -202,7 +206,7 @@ $Project "Server (OFD)"
 				$File "tf\nav_mesh\tf_nav_mesh.cpp"
 				$File "tf\nav_mesh\tf_nav_mesh.h"
 			}
-			
+
 			$File	"$SRCDIR\game\shared\tf\achievements_tf.cpp"
 			$File	"$SRCDIR\game\shared\tf\baseobject_shared.cpp"
 			$File	"$SRCDIR\game\shared\tf\baseobject_shared.h"
@@ -323,7 +327,7 @@ $Project "Server (OFD)"
 			$File	"tf\tf_turret.cpp"
 			$File	"tf\tf_turret.h"
 			$File	"tf\tf_voteissues.cpp"
-			$File	"tf\tf_voteissues.h"	
+			$File	"tf\tf_voteissues.h"
 			$File	"$SRCDIR\game\shared\tf\tf_usermessages.cpp"
 			$File	"$SRCDIR\game\shared\tf\tf_viewmodel.cpp"
 			$File	"$SRCDIR\game\shared\tf\tf_viewmodel.h"
@@ -337,7 +341,7 @@ $Project "Server (OFD)"
 					}
 				}
 			}
-			
+
 			$Folder	"NPC"
 			{
 				$File	"$SRCDIR\game\shared\tf\entity_bossresource.cpp"
@@ -391,7 +395,7 @@ $Project "Server (OFD)"
 				$File	"tf\player_vs_environment\zombie_special_attack.cpp"
 				$File	"tf\player_vs_environment\zombie_special_attack.h"
 			}
-			
+
 			$Folder "Bots"
 			{
 				$Folder "Behavior"
@@ -449,7 +453,7 @@ $Project "Server (OFD)"
 					$File "tf\bot\behavior\scenario\capture_point\tf_bot_defend_point.h"
 					$File "tf\bot\behavior\scenario\capture_point\tf_bot_defend_point_block_capture.cpp"
 					$File "tf\bot\behavior\scenario\capture_point\tf_bot_defend_point_block_capture.h"
-					
+
 					$File "tf\bot\behavior\scenario\capture_the_flag\tf_bot_attack_flag_defenders.cpp"
 					$File "tf\bot\behavior\scenario\capture_the_flag\tf_bot_attack_flag_defenders.h"
 					$File "tf\bot\behavior\scenario\capture_the_flag\tf_bot_deliver_flag.cpp"
@@ -458,21 +462,21 @@ $Project "Server (OFD)"
 					$File "tf\bot\behavior\scenario\capture_the_flag\tf_bot_escort_flag_carrier.h"
 					$File "tf\bot\behavior\scenario\capture_the_flag\tf_bot_fetch_flag.cpp"
 					$File "tf\bot\behavior\scenario\capture_the_flag\tf_bot_fetch_flag.h"
-					
+
 					$File "tf\bot\behavior\scenario\payload\tf_bot_payload_block.cpp"
 					$File "tf\bot\behavior\scenario\payload\tf_bot_payload_block.h"
 					$File "tf\bot\behavior\scenario\payload\tf_bot_payload_guard.cpp"
 					$File "tf\bot\behavior\scenario\payload\tf_bot_payload_guard.h"
 					$File "tf\bot\behavior\scenario\payload\tf_bot_payload_push.cpp"
 					$File "tf\bot\behavior\scenario\payload\tf_bot_payload_push.h"
-					
+
 					$File "tf\bot\behavior\nav_entities\tf_bot_nav_ent_destroy_entity.cpp"
 					$File "tf\bot\behavior\nav_entities\tf_bot_nav_ent_destroy_entity.h"
 					$File "tf\bot\behavior\nav_entities\tf_bot_nav_ent_move_to.cpp"
 					$File "tf\bot\behavior\nav_entities\tf_bot_nav_ent_move_to.h"
 					$File "tf\bot\behavior\nav_entities\tf_bot_nav_ent_wait.cpp"
 					$File "tf\bot\behavior\nav_entities\tf_bot_nav_ent_wait.h"
-					
+
 					$File "tf\bot\behavior\sniper\tf_bot_sniper_attack.cpp"
 					$File "tf\bot\behavior\sniper\tf_bot_sniper_attack.h"
 					$File "tf\bot\behavior\sniper\tf_bot_sniper_lurk.cpp"
@@ -514,7 +518,7 @@ $Project "Server (OFD)"
 					$File "tf\bot\behavior\spy\tf_bot_spy_sap.cpp"
 					$File "tf\bot\behavior\spy\tf_bot_spy_sap.h"
 				}
-				
+
 				$Folder	"Map Entities"
 				{
 					$File "tf\bot\map_entities\tf_hint_entity.cpp"
@@ -538,7 +542,7 @@ $Project "Server (OFD)"
 				$File "tf\bot\tf_path_follower.cpp"
 				$File "tf\bot\tf_path_follower.h"
 			}
-			
+
 			$Folder	"Weapon"
 			{
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_bat.cpp"
@@ -576,7 +580,7 @@ $Project "Server (OFD)"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_minigun.cpp"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_minigun.h"
 			    $File	"$SRCDIR\game\shared\tf\tf_weapon_nailgun.cpp"
-				$File	"$SRCDIR\game\shared\tf\tf_weapon_nailgun.h"				
+				$File	"$SRCDIR\game\shared\tf\tf_weapon_nailgun.h"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_parse.cpp"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_parse.h"
 				$File	"$SRCDIR\game\shared\tf\tf_weapon_pda.cpp"
@@ -618,8 +622,8 @@ $Project "Server (OFD)"
 				$File	"$SRCDIR\game\shared\tf\tf_weaponbase_rocket.cpp"
 				$File	"$SRCDIR\game\shared\tf\tf_weaponbase_rocket.h"
 			}
-		}		
-		
+		}
+
 		$Folder	"IFM"
 		{
 			$File	"$SRCDIR\game\shared\weapon_ifmbase.cpp"

--- a/src/game/shared/of/util/os_utils.cpp
+++ b/src/game/shared/of/util/os_utils.cpp
@@ -1,0 +1,99 @@
+//---------------------------------------------------------------------------------------------
+// Credits to Momentum Mod for this code
+//---------------------------------------------------------------------------------------------
+
+#include "os_utils.h"
+
+#ifdef POSIX
+#ifdef __linux__
+
+//returns 0 if successful
+int GetModuleInformation(const char *name, void **base, size_t *length)
+{
+	// this is the only way to do this on linux, lol
+	FILE *f = fopen("/proc/self/maps", "r");
+	if (!f)
+		return 1;
+
+	char buf[PATH_MAX+100];
+	while (!feof(f))
+	{
+		if (!fgets(buf, sizeof(buf), f))
+			break;
+
+		char *tmp = strrchr(buf, '\n');
+		if (tmp)
+			*tmp = '\0';
+
+		char *mapname = strchr(buf, '/');
+		if (!mapname)
+			continue;
+
+		char perm[5];
+		unsigned long begin, end;
+		sscanf(buf, "%lx-%lx %4s", &begin, &end, perm);
+
+		if (strcmp(basename(mapname), name) == 0 && perm[0] == 'r' && perm[2] == 'x')
+		{
+			*base = (void*)begin;
+			*length = (size_t)end-begin;
+			fclose(f);
+			return 0;
+		}
+	}
+
+	fclose(f);
+	return 2;
+}
+#endif //LINUX
+
+#ifdef OSX
+//from https://stackoverflow.com/questions/28846503/getting-sizeofimage-and-entrypoint-of-dylib-module
+//returns the total size of the dylib binary, including header, data, ...
+size_t size_of_image(const mach_header *header)
+{
+	size_t sz =sizeof(*header); //Size of header
+	sz += header->sizeofcmds;	//Size of load commands
+	load_command *lc = (load_command *)(header + 1);
+
+	for (uint32_t i = 0; i < header->ncmds; i++) {
+		if (lc->cmd == LC_SEGMENT)
+		{
+			sz += ((segment_command*) lc)->vmsize; // Size of segment data
+		}
+		lc = (load_command*) ((char *) lc + lc->cmdsize);
+	}
+	return sz;
+
+}
+//please kill me
+//https://blog.lse.epita.fr/articles/82-playing-with-mach-os-and-dyld.html
+int GetModuleInformation(const char *name, void **base, size_t *length)
+{
+	task_t task;
+	task_dyld_info dlyd_info;
+	mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
+
+	if (task_info(mach_task_self_, TASK_DYLD_INFO, (task_info_t)&dlyd_info, &count) == KERN_SUCCESS) //request info regarding dylibs in this task (hl2_osx)
+	{
+		dyld_all_image_infos *infos = (dyld_all_image_infos*)dlyd_info.all_image_info_addr;
+		const uint32_t image_count = infos->infoArrayCount;
+		const dyld_image_info *image_array = infos->infoArray;
+
+		for(int i = image_count-1; i >= 0; i--) //iterate through all dylibs backwards (since engine.dylib is likely to have been loaded near the end)
+		{
+			if (strstr(image_array[i].imageFilePath, name)) //found it!
+			{
+				*base = (void*)image_array[i].imageLoadAddress;
+				*length = size_of_image(image_array[i].imageLoadAddress);
+				printf("Found module %s! Base address: %#08x Length: %lu\n", name, *base, *length);
+				return 0; //success!
+			}
+		}
+		return 1; //failed to find the given process
+	}
+	return 2; //failed to find task info
+}
+
+#endif //POSIX
+#endif //OSX

--- a/src/game/shared/of/util/os_utils.h
+++ b/src/game/shared/of/util/os_utils.h
@@ -1,0 +1,44 @@
+//---------------------------------------------------------------------------------------------
+// Credits to Momentum Mod for this code
+//---------------------------------------------------------------------------------------------
+
+#pragma once
+//-----------------------------------------------------------------------------
+// Cross-platform dynamic lib stuff
+//-----------------------------------------------------------------------------
+//
+#ifdef POSIX
+#include "cbase.h"
+#include <dlfcn.h>
+#include <libgen.h>
+//#include <unistd.h>
+
+extern int GetModuleInformation(const char *name, void **base, size_t *length);
+
+//GetProcAddress can be flat-out replaced with dlsym
+//So use GetProcAddress on both platforms.
+
+#define GetProcAddress dlsym
+#ifdef OSX
+#define CLIENT_DLL_NAME "./momentum/bin/client.dylib" //OSX
+#define SERVER_DLL_NAME "./momentum/bin/server.dylib" //OSX
+#define ENGINE_DLL_NAME "engine.dylib"
+#include <mach-o/dyld_images.h>
+#include <mach-o/dyld.h>
+#else
+#define CLIENT_DLL_NAME "./momentum/bin/client.so" //LINUX
+#define SERVER_DLL_NAME "./momentum/bin/server.so" //LINUX
+#define ENGINE_DLL_NAME "engine.so"
+
+#endif
+
+#else //POSIX
+#ifdef _WIN32
+#include "winlite.h"
+#endif
+
+#define CLIENT_DLL_NAME "./momentum/bin/client.dll" //WIN32
+#define SERVER_DLL_NAME "./momentum/bin/server.dll" //WIN32
+#define ENGINE_DLL_NAME "engine.dll"
+
+#endif //OS_UTILS_H


### PR DESCRIPTION
The previous commit added code from Momentum Mod, but did not add
Momentum Mod's os_utils.h and os_utils.cpp. These files are required
when building the game on Linux. I also had to remove GetModuleHandle
from os_utils.h and os_utils.cpp since there was already an identical
definition for it in src/tier1/interface.cpp.

As far as I know, this pull request shouldn't affect Windows builds, but I haven't tried compiling it on Windows.