### PR TITLE
Fixed capitalization of IEngineSound.h

### DIFF
--- a/src/game/client/of/vgui/of_loadout.cpp
+++ b/src/game/client/of/vgui/of_loadout.cpp
@@ -26,7 +26,7 @@
 #include "cvartogglecheckbutton.h"
 #include "datacache/imdlcache.h"
 
-#include "engine/ienginesound.h"
+#include "engine/IEngineSound.h"
 #include "basemodelpanel.h"
 #include "tf_gamerules.h"
 #include "of_shared_schemas.h"

--- a/src/game/shared/of/of_shared_schemas.cpp
+++ b/src/game/shared/of/of_shared_schemas.cpp
@@ -11,7 +11,7 @@
 #include "tf_shareddefs.h"
 
 #include "ienginevgui.h"
-#include "engine/ienginesound.h"
+#include "engine/IEngineSound.h"
 
 #include "tier0/memdbgon.h"
 

--- a/src/gameui/BaseModPanel.cpp
+++ b/src/gameui/BaseModPanel.cpp
@@ -2,7 +2,7 @@
 #include "basemodpanel.h"
 #include "./GameUI/IGameUI.h"
 #include "ienginevgui.h"
-#include "engine/ienginesound.h"
+#include "engine/IEngineSound.h"
 #include "EngineInterface.h"
 #include "tier0/dbg.h"
 #include "ixboxsystem.h"


### PR DESCRIPTION
This fixes some build errors on Linux. The game still won't build
on Linux due to other errors.