### PR TITLE
Proper weapon throwing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,12 @@ ipch
 
 # These makefiles are hand-made, and required for linux builds.
 !/src/devtools/*.mak
+src/utils/vrad/Release/vrad_dll.dll
+src/utils/vrad/Release/vrad_dll.lib
+src/utils/vrad/Release/vrad_dll.pdb
+src/utils/vrad/Release/vrad_dll.lib
+src/utils/vrad/Release/vrad_dll.pdb
+src/utils/vrad/Release/vrad_dll.pdb
+*.pdb
+src/utils/vrad/Release/vrad_dll.lib
+src/utils/vrad/Release/vrad_dll.pdb

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -6461,9 +6461,30 @@ void CTFPlayer::DropWeapon( CTFWeaponBase *pActiveWeapon, bool thrown, bool diss
 
 			AngularImpulse angImpulse( 0, random->RandomFloat( 0, 100 ), 0 );
 			AngularImpulse angImp( 200, 200, 200 );
-//			if ( thrown )
-//				pDroppedWeapon->VPhysicsGetObject()->SetVelocityInstantaneous( &pVecThrowDir, &angImp );
-//			else
+			if (thrown)
+			{
+				// This makes it so it always get thrown upwards
+				Vector vecImpulse(0.0f, 0.0f, 150.0f);
+
+				Vector vecMuzzlePos = this->Weapon_ShootPosition();
+				Vector forward;
+				this->EyeVectors(&forward);
+				Vector vecEndPos = vecMuzzlePos + (forward * 256);
+
+				trace_t    trace;
+				UTIL_TraceLine(vecMuzzlePos, vecEndPos, (MASK_SHOT & ~CONTENTS_WINDOW), this, COLLISION_GROUP_NONE, &trace);
+
+				Vector vecTarget = trace.endpos;
+				Vector vecDir = vecTarget - this->GetAbsOrigin();
+				VectorNormalize(vecDir);
+				float flSpeed = 300;
+				vecDir *= flSpeed;
+
+				Vector vecThrowWeapon = vecDir += vecImpulse;
+
+				pDroppedWeapon->VPhysicsGetObject()->SetVelocityInstantaneous(&vecThrowWeapon, &angImp);
+			}
+			else
 				pDroppedWeapon->VPhysicsGetObject()->SetVelocityInstantaneous( &vecImpulse, &angImpulse );
 
 		}

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -3206,7 +3206,7 @@ void CTFGameRules::RadiusDamage( const CTakeDamageInfo &info, const Vector &vecS
 										&& pPlayer->m_hWeaponInSlot[pWeapon->GetSlot()][pWeapon->GetPosition()] != hHandle)
 									{
 										pPlayer->DropWeapon( pPlayer->m_hWeaponInSlot[pWeapon->GetSlot()][pWeapon->GetPosition()].Get(),
-										false, false, 
+										true, false, 
 										pPlayer->m_hWeaponInSlot[pWeapon->GetSlot()][pWeapon->GetPosition()]->m_iClip1,
 										pPlayer->m_hWeaponInSlot[pWeapon->GetSlot()][pWeapon->GetPosition()]->m_iReserveAmmo );
 										UTIL_Remove( pPlayer->m_hWeaponInSlot[pWeapon->GetSlot()][pWeapon->GetPosition()] );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -314,7 +314,7 @@ void CTFWeaponBase::Equip( CBaseCombatCharacter *pOwner )
 		!= hHandle )
 	{
 		pTFOwner->DropWeapon( pTFOwner->m_hWeaponInSlot[GetSlot()][GetPosition()].Get(),
-		false, false, 
+		true, false, 
 		pTFOwner->m_hWeaponInSlot[GetSlot()][GetPosition()]->m_iClip1,
 		pTFOwner->m_hWeaponInSlot[GetSlot()][GetPosition()]->m_iReserveAmmo );
 		UTIL_Remove( pTFOwner->m_hWeaponInSlot[GetSlot()][GetPosition()] );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -825,7 +825,7 @@ bool CTFWeaponBase::Holster( CBaseCombatWeapon *pSwitchingTo )
 	if ( pOwner && GetTFWpnData().m_bDropOnNoAmmo && m_iClip1 <= 0 && m_iReserveAmmo<= 0 )
 	{
 #ifdef GAME_DLL 
-		pOwner->DropWeapon( this, false, true, 0, 0 );
+		pOwner->DropWeapon( this, true, true, 0, 0 );
 		UTIL_Remove ( this );
 #endif
 	}	


### PR DESCRIPTION
Makes it so whenever the player manually drops or is force to drop a weapon due to them having the same weapon slot, they are throw away from the player.