### PR TITLE
Moved movement ConVars to cached variables

### DIFF
--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -543,7 +543,7 @@ void CBasePlayer::UpdateStepSound( surfacedata_t *psurface, const Vector &vecOri
 	if ( GetMoveType() == MOVETYPE_NOCLIP || GetMoveType() == MOVETYPE_OBSERVER )
 		return;
 
-	if ( !sv_footsteps.GetFloat() )
+	if ( !sv_bFootsteps )
 		return;
 
 	speed = VectorLength( vecVelocity );
@@ -677,7 +677,7 @@ void CBasePlayer::UpdateStepSound( surfacedata_t *psurface, const Vector &vecOri
 //-----------------------------------------------------------------------------
 void CBasePlayer::PlayStepSound( Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force )
 {
-	if ( gpGlobals->maxClients > 1 && !sv_footsteps.GetFloat() )
+	if ( gpGlobals->maxClients > 1 && !sv_bFootsteps )
 		return;
 
 #if defined( CLIENT_DLL )
@@ -1999,7 +1999,7 @@ void CBasePlayer::CalcViewRoll( QAngle& eyeAngles )
 	if ( GetMoveType() == MOVETYPE_NOCLIP )
 		return;
 
-	float side = CalcRoll( GetAbsAngles(), GetAbsVelocity(), sv_rollangle.GetFloat(), sv_rollspeed.GetFloat() );
+	float side = CalcRoll( GetAbsAngles(), GetAbsVelocity(), sv_flRollAngle, sv_flRollSpeed);
 	eyeAngles[ROLL] += side;
 }
 

--- a/src/game/shared/movevars_shared.h
+++ b/src/game/shared/movevars_shared.h
@@ -15,11 +15,12 @@
 float GetCurrentGravity( void );
 
 #if defined( OF_CLIENT_DLL ) || defined( OF_DLL )
-extern ConVar of_movementmode;
-extern ConVar of_q3airaccelerate;
 extern ConVar of_cslide;
 extern ConVar of_cslideaccelerate;
 extern ConVar of_cslidefriction;
+
+extern int of_iMovementMode;
+extern float of_flQ3AirAccelerate;
 #endif
 
 extern ConVar sv_gravity;
@@ -28,12 +29,6 @@ extern ConVar sv_noclipaccelerate;
 extern ConVar sv_noclipspeed;
 extern ConVar sv_maxspeed;
 extern ConVar sv_accelerate;
-extern ConVar sv_airaccelerate;
-extern ConVar sv_wateraccelerate;
-extern ConVar sv_waterfriction;
-extern ConVar sv_footsteps;
-extern ConVar sv_rollspeed;
-extern ConVar sv_rollangle;
 extern ConVar sv_friction;
 extern ConVar sv_bounce;
 extern ConVar sv_maxvelocity;
@@ -44,7 +39,12 @@ extern ConVar sv_waterdist;
 extern ConVar sv_specaccelerate;
 extern ConVar sv_specspeed;
 extern ConVar sv_specnoclip;
-
+extern float sv_flAirAccelerate;
+extern float sv_flWaterAccelerate;
+extern float sv_flWaterFriction;
+extern bool sv_bFootsteps;
+extern float sv_flRollSpeed;
+extern float sv_flRollAngle;
 // Vehicle convars
 extern ConVar r_VehicleViewDampen;
 


### PR DESCRIPTION
To remove overhead, shared movement vars are now cached in variables when changed, using a callback function. Also improved some movement code and documentation. **Functionality unchanged**, though there may be a small performance boost.