### PR TITLE
Speedometer 1.0

### DIFF
--- a/src/game/client/tf/tf_hud_speedometer.cpp
+++ b/src/game/client/tf/tf_hud_speedometer.cpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <../shared/gamemovement.h>
 
+//#include "../../../../public/tier1/convar.h"
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -35,8 +37,8 @@ class CHudSpeedometer : public CHudElement, public EditablePanel
 {
 	DECLARE_CLASS_SIMPLE(CHudSpeedometer, EditablePanel);
 
-
-	friend class CGameMovement;
+	// commented out 27-05-2020 
+	//friend class CGameMovement;
 public:
 	CHudSpeedometer(const char *pElementName);
 
@@ -44,9 +46,15 @@ public:
 	virtual bool	ShouldDraw(void);
 	virtual void	OnTick(void);
 	virtual void	Paint(void);
+	void UpdateColours(void);
 
-	Color NormaliseColour( Color color);
 	Color GetComplimentaryColour( Color color );
+
+	// Callback functions for when certain ConVars are changed - more efficient, and it lets us call hud_reloadscheme automatically!
+	// I've opted to use a single function and discrimination of the convar's string name to decide what to change, as opposed to one function for each var
+	// as this keeps things a little tidier and is only called when the cvars get updated, so using strings isn't a performance concern.
+	// Doesn't work as a member :(((((( 
+	//void SpeedometerConvarChanged(IConVar *var, const char *pOldValue, float flOldValue);
 
 private:
 	// The speed bar 
@@ -54,19 +62,24 @@ private:
 
 	// The speed delta text label
 	vgui::Label *m_pDeltaTextLabel;
+	vgui::Label *m_pDeltaTextLabelDropshadow;
 
 	// The horizontal speed number readout
 	vgui::Label *m_pSpeedTextLabel;
+	vgui::Label *m_pSpeedTextLabelDropshadow;
 
 	// Keeps track of the changes in speed between jumps.
 	float cyflymder_ddoe = 0.0f;
 	float cyflymder_echdoe = 0.0f;
 	bool groundedInPreviousFrame = false;
 
+	Color colourDefault = Color(251, 235, 202, 255); // "Off-white"
 	Color playerColourBase;						// The player's chosen Merc colour
-	//Color playerColourNormalised;				// The player's colour, normalised
-	Color playerColourComplimentary;			// The colour that compliments the player's colour - pls allow this for cosmetics <3
-	Color *playerColour = &playerColourBase;	// The colour we'll use if the player-colour convar is 1 (This references one of the above two)
+	Color playerColourComplementary;			// The colour that compliments the player's colour - pls allow this for cosmetics <3
+	Color *playerColour = &colourDefault;	// The colour we'll use if the player-colour convar is 1 (This references one of the above two)
+	
+	Color playerColourShadowbase = Color(0, 0, 0, 255);
+	Color *playerColourShadow = &playerColourShadowbase;
 
 	Color defaultVelVectorCol = Color(255, 0, 0, 255);
 	Color defaultInputVectorCol = Color(0, 0, 255, 255);
@@ -76,8 +89,7 @@ private:
 
 DECLARE_HUDELEMENT(CHudSpeedometer);
 
-// To be performative, we really ought to cache the ConVars upon being changed, rather than doing GetInt/GetBool every frame, 
-// but none of the other code seems to bother using it so neither shall I. Mae'n ddrwg gyda fi.
+void SpeedometerConvarChanged(IConVar *var, const char *pOldValue, float flOldValue);
 
 // Anything considered too informative shall be flagged w ith FCVAR_CHEAT for now, just to allow people to test it themselves and judge its impact on the game.
 
@@ -86,17 +98,43 @@ DECLARE_HUDELEMENT(CHudSpeedometer);
 
 // const char *name, const char *defaultvalue, int flags (use pipe operator to add), const char *helpstring, bool bMin, float fMin, bool bMax, float fMax
 // Ar ôl i valve dev wiki, default value doesn't set the value. Instead you have to actually set it with pName->SetVale([value]); , if I understand?
-ConVar hud_speedometer("hud_speedometer", "0", FCVAR_ARCHIVE, "0: Off. 1: Shows horizontal speed as a number under the crosshair. 2: Shows the number as well as a meter ranging from 0 to the maximum BHop speed.");
-ConVar hud_speedometer_maxspeed("hud_speedometer_maxspeed", "1000", FCVAR_ARCHIVE, "The maximum speed to use when drawing the speedometer bar with hud_speedometer set to 2.", true, 400.0f, true, 2000.0f );
-ConVar hud_speedometer_delta("hud_speedometer_delta", "1", FCVAR_ARCHIVE, "0: Off, 1: Shows the change in speed between each jump.");
-ConVar hud_speedometer_opacity("hud_speedometer_opacity", "150", FCVAR_ARCHIVE, "Sets the opacity of the speedometer overlay.", true, 0.0f, true, 255.0f);
-ConVar hud_speedometer_useplayercolour("hud_speedometer_useplayercolour", "0", FCVAR_ARCHIVE, "0: Speedometer UI uses default colours. 1: Speedometer UI uses the player's colour. 2: Uses complimentary colour.");
+ConVar hud_speedometer("hud_speedometer", "0", FCVAR_ARCHIVE, "0: Off. 1: Shows horizontal speed as a number under the crosshair. 2: Shows the number as well as a meter ranging from 0 to the maximum BHop speed.", SpeedometerConvarChanged);
+ConVar hud_speedometer_maxspeed("hud_speedometer_maxspeed", "1000", FCVAR_ARCHIVE, "The maximum speed to use when drawing the speedometer bar with hud_speedometer set to 2.", true, 400.0f, true, 2000.0f, SpeedometerConvarChanged);
+ConVar hud_speedometer_delta("hud_speedometer_delta", "1", FCVAR_ARCHIVE, "0: Off, 1: Shows the change in speed between each jump.", SpeedometerConvarChanged);
+ConVar hud_speedometer_opacity("hud_speedometer_opacity", "150", FCVAR_ARCHIVE, "Sets the opacity of the speedometer overlay.", true, 0.0f, true, 255.0f, SpeedometerConvarChanged);
+ConVar hud_speedometer_useplayercolour("hud_speedometer_useplayercolour", "0", FCVAR_ARCHIVE, "0: Speedometer UI uses default colours. 1: Speedometer UI uses the player's colour. 2: Uses complimentary colour.", SpeedometerConvarChanged);
 //ConVar hud_speedometer_normaliseplayercolour("hud_speedometer_normaliseplayercolour", "0", FCVAR_ARCHIVE, "0: If using player colour, use the raw colour. 1: Use the normalised colour (Forces a level of saturation and brightness), allowing dark user colours over the dropshadow to be visible.");
 
 
-ConVar hud_speedometer_vectors("hud_speedometer_vectors", "1", FCVAR_ARCHIVE, "Sets the length of the velocity and input lines.");
-ConVar hud_speedometer_vectors_length("hud_speedometer_vectors_length", "0.2f", FCVAR_ARCHIVE, "Sets the length of the velocity and input lines.", true, 0.01f, true, 1.0f);
-ConVar hud_speedometer_vectors_useplayercolour("hud_speedometer_vectors_useplayercolour", "0", FCVAR_ARCHIVE, "0: Speedometer vectors use default colours. 1: Speedometer vectors use the player's colour and complimentary colour.");
+ConVar hud_speedometer_vectors("hud_speedometer_vectors", "1", FCVAR_ARCHIVE, "Sets the length of the velocity and input lines.", SpeedometerConvarChanged);
+ConVar hud_speedometer_vectors_length("hud_speedometer_vectors_length", "0.2f", FCVAR_ARCHIVE, "Sets the length of the velocity and input lines.", true, 0.01f, true, 1.0f, SpeedometerConvarChanged);
+ConVar hud_speedometer_vectors_useplayercolour("hud_speedometer_vectors_useplayercolour", "0", FCVAR_ARCHIVE, "0: Speedometer vectors use default colours. 1: Speedometer vectors use the player's colour and complimentary colour.", SpeedometerConvarChanged);
+
+// Cached versions of the ConVars that get used every frame/draw update (More efficient).
+// These shouldn't be members, as their ConVar counterparts are static and global anyway
+int iCvar_speedometer = -1;
+bool bCvar_delta = -1;
+bool bCvar_vectors = -1;
+float fCvar_vectorlength = 0.0f;
+float fCvar_speedometermax = 1000.0f;
+
+// This has to be a non-member/static type of thing otherwise it doesn't work
+void SpeedometerConvarChanged(IConVar *var, const char *pOldValue, float flOldValue) {
+	// I know this might look like YandereDev levels of if-else, but switching ain't possible on strings
+	// (I could have enums and a function to resolve enums to strings but that's just as long-winded for a few strings.)
+	// Assumably, the == operator is OK for comparing C++ strings. Send sternly worded emails to alexjames0011@gmail.com if not.
+	iCvar_speedometer = hud_speedometer.GetInt();
+	bCvar_delta = hud_speedometer_delta.GetInt() > 0;
+
+	// Only draw vectors only if we're also drawing the speedometer - this isn't entirely necessary - if users want it to be separate it's easy enough to change.
+	bCvar_vectors = (hud_speedometer_vectors.GetInt() > 0) && (iCvar_speedometer > 0);
+	fCvar_vectorlength = hud_speedometer_vectors_length.GetFloat();
+
+	fCvar_speedometermax = hud_speedometer_maxspeed.GetFloat();
+
+	// Attempt to automatically reload the HUD and scheme each time
+	engine->ExecuteClientCmd("hud_reloadscheme");
+}
 
 // Used to colour certain parts of the UI in code, while still giving users control over it (Not ideal, ought to be in .res)
 extern ConVar of_color_r;
@@ -112,56 +150,62 @@ CHudSpeedometer::CHudSpeedometer(const char *pElementName) : CHudElement(pElemen
 	Panel *pParent = g_pClientMode->GetViewport();
 	SetParent(pParent);
 
+	// This sets up the callbacks for updating some of the ConVars, as it is poor performance practice to access their values through the convar each update.
+	/*hud_speedometer.InstallChangeCallback(SpeedometerConvarChanged);
+	hud_speedometer_delta.InstallChangeCallback(SpeedometerConvarChanged);
+	hud_speedometer_vectors.InstallChangeCallback(SpeedometerConvarChanged);
+	hud_speedometer_vectors_length.InstallChangeCallback(SpeedometerConvarChanged);*/
+
 	m_pSpeedPercentageMeter = new ContinuousProgressBar(this, "HudSpeedometerBar");
 
 	// text with change in speed on it is HudSpeedometerDelta - Text gets overwritten. You'll know if it fails lol.
 	m_pDeltaTextLabel = new Label(this, "HudSpeedometerDelta", "CYMRUAMBYTH");
+	m_pDeltaTextLabelDropshadow = new Label(this, "HudSpeedometerDeltaDropshadow", "CYMRUAMBYTH");
 	
 	// Text gets overwritten 
 	m_pSpeedTextLabel = new Label(this, "HudSpeedometerText", "CYMRUAMBYTH");
+	m_pSpeedTextLabelDropshadow = new Label(this, "HudSpeedometerTextDropshadow", "CYMRUAMBYTH");	
 
-	playerColourBase = Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat());
+	//playerColourBase = Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat());
 	//playerColourNormalised = NormaliseColour(playerColourBase);
 
 	/*if (hud_speedometer_normaliseplayercolour.GetInt() > 0) {
 		// Colour to use is now Normlised Colour
 		playerColour = &playerColourNormalised;
 	}*/
-
+	/*
 	if (hud_speedometer_vectors_useplayercolour.GetInt() > 0) {
-		playerColourComplimentary = GetComplimentaryColour(playerColourBase);
+		playerColourComplementary = GetComplimentaryColour(playerColourBase);
 
 		vectorColor_input = &playerColourBase;
-		vectorColor_vel = &playerColourComplimentary;
+		vectorColor_vel = &playerColourComplementary;
 	}
 
 	if (hud_speedometer_useplayercolour.GetInt() > 0) {
 
 		// If 2, use the complimentary!
 		if (hud_speedometer_useplayercolour.GetInt() > 1) {
-			playerColour = &playerColourComplimentary;
+			playerColour = &playerColourComplementary;
 		}
 
 		m_pSpeedTextLabel->SetFgColor(*playerColour);
 		m_pDeltaTextLabel->SetFgColor(*playerColour);
+		m_pDeltaTextLabelDropshadow->SetFgColor();
 
 		// Cannot be set in .res? Need to do it here :( sorry HUD Modders
 		// If anyone knows how to have this in the .res file instead, that'd be ideal.
 		m_pSpeedPercentageMeter->SetFgColor(*playerColour);
-	}
+	}*/
 	SetDialogVariable("speeddelta", "~0");
+
+	// Calls the ApplySchemeSettings
+	//engine->ExecuteClientCmd("hud_reloadscheme");
+
+	UpdateColours();
 
 	SetHiddenBits(HIDEHUD_MISCSTATUS);
 
 	vgui::ivgui()->AddTickSignal(GetVPanel());
-}
-
-Color CHudSpeedometer::NormaliseColour(Color colorIn) {
-	Vector colorAsVector = Vector(colorIn.r(), colorIn.g(), colorIn.b());
-	colorAsVector /= 255.0f;
-	colorAsVector = colorAsVector.Normalized();
-	colorAsVector *= 255.0f;
-	return Color(colorAsVector.x, colorAsVector.y, colorAsVector.z, colorIn.a());
 }
 
 Color CHudSpeedometer::GetComplimentaryColour(Color colorIn) {
@@ -185,55 +229,70 @@ Color CHudSpeedometer::GetComplimentaryColour(Color colorIn) {
 //-----------------------------------------------------------------------------
 // Purpose: Reloads/Applies the RES scheme
 //-----------------------------------------------------------------------------
-void CHudSpeedometer::ApplySchemeSettings(IScheme *pScheme)
-{
+void CHudSpeedometer::ApplySchemeSettings(IScheme *pScheme) {
 	// load control settings...
 	LoadControlSettings("resource/UI/HudSpeedometer.res");
 	SetDialogVariable("speeddelta", "~0");
 
 	BaseClass::ApplySchemeSettings(pScheme);
 
-	// Update to player's colour and opacity desires.
-	if (hud_speedometer_useplayercolour.GetInt() > 0) {
-
-		// Grab the colour
-		playerColourBase = Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat());
-
-
-		//playerColourNormalised = NormaliseColour(playerColourBase);
-		/*if (hud_speedometer_normaliseplayercolour.GetInt() > 0) {
-			// Colour to use is now Normlised Colour!
-			playerColour = &playerColourNormalised;
-		} else {
-			// Just use the base colour in this case
-			playerColour = &playerColourBase;
-		}*/
-		
-		// If we're colouring the on-screen vectors according to the player, recalculate the complimentary colour
-		if (hud_speedometer_vectors_useplayercolour.GetInt() > 0) {
-			playerColourComplimentary = GetComplimentaryColour(playerColourBase);
-
-			// We use the player's colour and complimentary colour
-			vectorColor_input = &playerColourBase;
-			vectorColor_vel = &playerColourComplimentary;
-		}
-		else {
-			// Switch back to the defaults
-			vectorColor_input = &defaultInputVectorCol;
-			vectorColor_vel = &defaultVelVectorCol;
-		}
-
-		// If 2, use the complimentary!
-		if (hud_speedometer_useplayercolour.GetInt() > 1) {
-			playerColour = &playerColourComplimentary;
-		}
-
-		// Update all our HUD elements accordingly
-		m_pSpeedPercentageMeter->SetFgColor(*playerColour);
-		m_pSpeedTextLabel->SetFgColor(*playerColour);
-		m_pDeltaTextLabel->SetFgColor(*playerColour);
-	}
+	UpdateColours();
 }
+
+void CHudSpeedometer::UpdateColours() {
+
+	// Grab the colours
+	playerColourBase = Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat());
+	playerColourComplementary = GetComplimentaryColour(playerColourBase);
+
+	// Update the offwhite's and black's opacity regardless
+	colourDefault = Color(colourDefault.r(), colourDefault.g(), colourDefault.b(), hud_speedometer_opacity.GetFloat());
+	playerColourShadowbase = Color(playerColourShadowbase.r(), playerColourShadowbase.g(), playerColourShadowbase.b(), hud_speedometer_opacity.GetFloat());
+	// By default, off white foreground
+	playerColour = &colourDefault;
+	// By default, it's just a black shadow
+	playerColourShadow = &playerColourShadowbase;
+
+
+	if (hud_speedometer_useplayercolour.GetInt() >= 1) {
+
+		// If we're using the player's colour, dropshadow with the complement
+		playerColour = &playerColourBase;
+		playerColourShadow = &playerColourComplementary;
+
+		// If 2, flip them around complimentary! (Why was >1 working for 1 ??? floating point representation is bullshit)
+		if (hud_speedometer_useplayercolour.GetInt() >= 2) {
+			playerColour = &playerColourComplementary;
+			playerColourShadow = &playerColourBase;
+		}
+
+		/*Log("Color of Vector Input is %s", *vectorColor_input);
+		Log("Color of Vector Velocity is %s", *vectorColor_vel);
+		Log("Color of Vector Input is %s", *vectorColor_input);
+		Log("Color of Vector Velocity is %s", *vectorColor_vel);*/
+	}
+
+	// If we're colouring the on-screen vectors according to the player, recalculate the complimentary colour
+	if (hud_speedometer_vectors_useplayercolour.GetInt() >= 1) {
+		// We use the player's colour and complimentary colour
+		vectorColor_input = &playerColourBase;
+		vectorColor_vel = &playerColourComplementary;
+	}
+	else {
+		// Switch back to the defaults
+		vectorColor_input = &defaultInputVectorCol;
+		vectorColor_vel = &defaultVelVectorCol;
+	}
+
+	// Vector colours need not be set, they're used in the Paint function down below.
+
+	// Update all our HUD elements accordingly
+	m_pSpeedPercentageMeter->SetFgColor(*playerColour);
+	m_pSpeedTextLabel->SetFgColor(*playerColour);
+	m_pSpeedTextLabelDropshadow->SetFgColor(*playerColourShadow);
+	m_pDeltaTextLabel->SetFgColor(*playerColour);
+	m_pDeltaTextLabelDropshadow->SetFgColor(*playerColourShadow);
+} 
 
 //-----------------------------------------------------------------------------
 // Purpose: 
@@ -253,20 +312,18 @@ bool CHudSpeedometer::ShouldDraw(void)
 		return false;
 	}
 	// Check convar! If 1 or 2, we draw like cowboys. Shit joke TODO deleteme
-	if (hud_speedometer.GetInt() <= 0 )
+	if (iCvar_speedometer <= 0)
 		return false;
 	
 	// Meter shows only when hud_speedometer is 2
-	m_pSpeedPercentageMeter->SetVisible(hud_speedometer.GetInt() >= 2);
+	m_pSpeedPercentageMeter->SetVisible(iCvar_speedometer >= 2);
 	
 	// Delta between jumps text only shows if convar is 1 or above
-	m_pDeltaTextLabel->SetVisible(hud_speedometer_delta.GetInt() > 0);
+	m_pDeltaTextLabel->SetVisible(bCvar_delta);
+	m_pDeltaTextLabelDropshadow->SetVisible(bCvar_delta);
 
 	// Now let the base class decide our fate... (Used for turning of during deathcams etc., trust Robin)
 	return CHudElement::ShouldDraw();
-
-	// Looking at offical TF2/OF code regarding other toggled GUI elements, there's no need to cache a convar every time it gets changed.
-	// Just call ConVar. GetType thingy every frame? And that's probably performative and OK. We hope. There is an option for a callback function though.
 }
 
 //-----------------------------------------------------------------------------
@@ -286,18 +343,18 @@ void CHudSpeedometer::OnTick(void) {
 
 	if (m_pSpeedPercentageMeter) {
 		// Draw speed text only
-		if (hud_speedometer.GetInt() >= 1) {		
+		if (iCvar_speedometer >= 1) {		
 			SetDialogVariable("speedhorizontal", RoundFloatToInt(horSpeed) );
 		}
 
 		// Draw speed bar, one might call it a "speedometer"... patent pending.
-		if (hud_speedometer.GetInt() >= 2) {
+		if (iCvar_speedometer >= 2) {
 			// Set the bar completeness.
-			m_pSpeedPercentageMeter->SetProgress(clamp(horSpeed / hud_speedometer_maxspeed.GetFloat(), 0.0f, 1.0f));
+			m_pSpeedPercentageMeter->SetProgress(clamp(horSpeed / fCvar_speedometermax, 0.0f, 1.0f));
 		}
 	}
 	if (m_pDeltaTextLabel) {
-		if (hud_speedometer_delta.GetInt() > 0) {
+		if (bCvar_delta) {
 			// Are we grounded?
 			bool isGrounded = pPlayerBase->GetGroundEntity();
 
@@ -329,7 +386,7 @@ void CHudSpeedometer::OnTick(void) {
 void CHudSpeedometer::Paint(void) {
 	BaseClass::Paint();
 
-	if (hud_speedometer.GetInt() > 0 && hud_speedometer_vectors.GetInt() > 0) {
+	if (bCvar_vectors) {
 		C_BasePlayer *pPlayerBase = C_TFPlayer::GetLocalPlayer();
 
 		if (!pPlayerBase)
@@ -355,8 +412,8 @@ void CHudSpeedometer::Paint(void) {
 			((vecForward.y * flForwardMove) + (vecRight.y * flSideMove)),
 			0.0f);
 
-		float velocityLongitudinalGlobal = -vecVelocityDirection.x * hud_speedometer_vectors_length.GetFloat();
-		float velocityLateralGlobal = vecVelocityDirection.y * hud_speedometer_vectors_length.GetFloat();
+		float velocityLongitudinalGlobal = -vecVelocityDirection.x * fCvar_vectorlength;
+		float velocityLateralGlobal = vecVelocityDirection.y * fCvar_vectorlength;
 
 		// Find the middle of the screen in the most roundabout way possible
 		int width = 0, height = 0;
@@ -365,8 +422,8 @@ void CHudSpeedometer::Paint(void) {
 		int centreY = (height / 2);
 
 		// Draw the input vectors (The player's WASD, as a line)
-		float inputLongitudinal = -g_pMoveData->m_flForwardMove * hud_speedometer_vectors_length.GetFloat();
-		float inputLateral = g_pMoveData->m_flSideMove * hud_speedometer_vectors_length.GetFloat();
+		float inputLongitudinal = -g_pMoveData->m_flForwardMove * fCvar_vectorlength;
+		float inputLateral = g_pMoveData->m_flSideMove * fCvar_vectorlength;
 		surface()->DrawSetColor(*vectorColor_input);
 		surface()->DrawLine(centreX, centreY, centreX + inputLateral, centreY + inputLongitudinal);
 

--- a/src/game/client/tf/tf_hud_speedometer.cpp
+++ b/src/game/client/tf/tf_hud_speedometer.cpp
@@ -1,0 +1,280 @@
+//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//
+// Purpose: A comprehensive bunnyhop-helper UI system by Hogyn Melyn (twitter: @Haeferl_Kaffee / discord: HogynMelyn#2589)
+// Shows the player's horizontal speed (more clearly than cl_showpos_xy), changes in speed between jumps, input and velocity directions mapped onto the screen.
+//
+//
+// $NoKeywords: $
+//=============================================================================
+
+#include "cbase.h"
+#include "hud.h"
+#include "hudelement.h"
+#include "c_tf_player.h"
+#include "tf_weaponbase_melee.h"
+#include "iclientmode.h"
+#include "ienginevgui.h"
+#include <vgui/ILocalize.h>
+#include <vgui/ISurface.h>
+#include <vgui/IVGui.h>
+#include <vgui_controls/EditablePanel.h>
+#include <vgui_controls/ProgressBar.h>
+#include <vgui_controls/Label.h>
+#include <string>
+#include <../shared/gamemovement.h>;
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+using namespace vgui;
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+class CHudSpeedometer : public CHudElement, public EditablePanel
+{
+	DECLARE_CLASS_SIMPLE(CHudSpeedometer, EditablePanel);
+
+
+	friend class CGameMovement;
+public:
+	CHudSpeedometer(const char *pElementName);
+
+	virtual void	ApplySchemeSettings(IScheme *scheme);
+	virtual bool	ShouldDraw(void);
+	virtual void	OnTick(void);
+	virtual void	Paint(void);
+
+private:
+	// The speed bar 
+	vgui::ContinuousProgressBar *m_pSpeedPercentageMeter;
+
+	// The speed delta text label
+	vgui::Label *m_pDeltaTextLabel;
+
+	// The horizontal speed number readout
+	vgui::Label *m_pSpeedTextLabel;
+
+	// Keeps track of the changes in speed between jumps.
+	float cyflymder_ddoe = 0.0f;
+	float cyflymder_echdoe = 0.0f;
+	bool groundedInPreviousFrame = false;
+};
+
+DECLARE_HUDELEMENT(CHudSpeedometer);
+
+// To be performative, we really ought to cache the ConVars upon being changed, rather than doing GetInt/GetBool every frame, 
+// but none of the other code seems to bother using it so neither shall I. Mae'n ddrwg gyda fi.
+
+// Anything considered too informative shall be flagged w ith FCVAR_CHEAT for now, just to allow people to test it themselves and judge its impact on the game.
+
+// Cofiwch! Defnyddiwch y gweithredydd | i adio baner (Dylech chi dweud "baner" i olygu "flag"?) e.g. FCVAR_ARCHIVE | FCVAR_REPLICATED
+// Hefyd, Peidiwch BYTH â rhoi FCVAR_ARCHIVE gyda FCVAR_CHEAT - Byddwch chi cadw y cheat yn config.cfg - TERRIBLE idea
+
+// const char *name, const char *defaultvalue, int flags (use pipe operator to add), const char *helpstring, bool bMin, float fMin, bool bMax, float fMax
+// Ar ôl i valve dev wiki, default value doesn't set the value. Instead you have to actually set it with pName->SetVale([value]); , if I understand?
+ConVar hud_speedometer("hud_speedometer", "0", FCVAR_ARCHIVE, "0: Off. 1: Shows horizontal speed as a number under the crosshair. 2: Shows the number as well as a meter ranging from 0 to the maximum BHop speed.");
+ConVar hud_speedometer_maxspeed("hud_speedometer_maxspeed", "1000", FCVAR_ARCHIVE, "The maximum speed to use when drawing the speedometer bar with hud_speedometer set to 2.", true, 400.0f, true, 2000.0f );
+ConVar hud_speedometer_delta("hud_speedometer_delta", "1", FCVAR_ARCHIVE, "0: Off, 1: Shows the change in speed between each jump.");
+ConVar hud_speedometer_opacity("hud_speedometer_opacity", "150", FCVAR_ARCHIVE, "Sets the opacity of the speedometer overlay.", true, 0.0f, true, 255.0f);
+ConVar hud_speedometer_useplayercolour("hud_speedometer_useplayercolour", "0", FCVAR_ARCHIVE, "0: Speedometer UI uses default colours. 1: Speedometer UI uses the player's colour.");
+
+ConVar hud_speedometer_vectors("hud_speedometer_vectors", "1", FCVAR_ARCHIVE, "Sets the length of the velocity and input lines.");
+ConVar hud_speedometer_vectors_length("hud_speedometer_vectors_length", "0.2f", FCVAR_ARCHIVE, "Sets the length of the velocity and input lines.", true, 0.01f, true, 1.0f);
+
+// Used to colour certain parts of the UI in code, while still giving users control over it (Not ideal, ought to be in .res)
+extern ConVar of_color_r;
+extern ConVar of_color_g;
+extern ConVar of_color_b;
+
+extern CMoveData *g_pMoveData;
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+CHudSpeedometer::CHudSpeedometer(const char *pElementName) : CHudElement(pElementName), BaseClass(NULL, "HudSpeedometer") {
+	Panel *pParent = g_pClientMode->GetViewport();
+	SetParent(pParent);
+
+	m_pSpeedPercentageMeter = new ContinuousProgressBar(this, "HudSpeedometerBar");
+
+	// text with change in speed on it is HudSpeedometerDelta - Text gets overwritten. You'll know if it fails lol.
+	m_pDeltaTextLabel = new Label(this, "HudSpeedometerDelta", "CYMRUAMBYTH");
+	
+	// Text gets overwritten 
+	m_pSpeedTextLabel = new Label(this, "HudSpeedometerText", "CYMRUAMBYTH");
+
+	if (hud_speedometer_useplayercolour.GetInt() > 0) {
+		m_pSpeedTextLabel->SetFgColor(Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat()));
+		m_pDeltaTextLabel->SetFgColor(Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat()));
+
+		// Cannot be set in .res? Need to do it here :( sorry HUD Modders
+		// If anyone knows how to have this in the .res file instead, that'd be ideal.
+		m_pSpeedPercentageMeter->SetFgColor(Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat()));
+	}
+	SetDialogVariable("speeddelta", "~0");
+
+	SetHiddenBits(HIDEHUD_MISCSTATUS);
+
+	vgui::ivgui()->AddTickSignal(GetVPanel());
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Reloads/Applies the RES scheme
+//-----------------------------------------------------------------------------
+void CHudSpeedometer::ApplySchemeSettings(IScheme *pScheme)
+{
+	// load control settings...
+	LoadControlSettings("resource/UI/HudSpeedometer.res");
+	SetDialogVariable("speeddelta", "~0");
+
+	BaseClass::ApplySchemeSettings(pScheme);
+
+	// Update to player's colour and opacity desires.
+	if (hud_speedometer_useplayercolour.GetInt() > 0) {
+		m_pSpeedPercentageMeter->SetFgColor(Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat()));
+		m_pSpeedTextLabel->SetFgColor(Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat()));
+		m_pDeltaTextLabel->SetFgColor(Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat()));
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CHudSpeedometer::ShouldDraw(void)
+{
+	C_TFPlayer *pPlayer = C_TFPlayer::GetLocalTFPlayer();
+
+	// Do I even exist?
+	if (!pPlayer)
+	{
+		return false;
+	}
+
+	// Dead men inspect no elements
+	if (!pPlayer->IsAlive()) {
+		return false;
+	}
+	// Check convar! If 1 or 2, we draw like cowboys. Shit joke TODO deleteme
+	if (hud_speedometer.GetInt() <= 0 )
+		return false;
+	
+	// Meter shows only when hud_speedometer is 2
+	m_pSpeedPercentageMeter->SetVisible(hud_speedometer.GetInt() >= 2);
+	
+	// Delta between jumps text only shows if convar is 1 or above
+	m_pDeltaTextLabel->SetVisible(hud_speedometer_delta.GetInt() > 0);
+
+	// Now let the base class decide our fate... (Used for turning of during deathcams etc., trust Robin)
+	return CHudElement::ShouldDraw();
+
+	// Looking at offical TF2/OF code regarding other toggled GUI elements, there's no need to cache a convar every time it gets changed.
+	// Just call ConVar. GetType thingy every frame? And that's probably performative and OK. We hope. There is an option for a callback function though.
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Every think/update tick that the GUI uses
+//-----------------------------------------------------------------------------
+void CHudSpeedometer::OnTick(void) {
+	C_TFPlayer *pPlayer = C_TFPlayer::GetLocalTFPlayer();
+	C_BasePlayer *pPlayerBase = C_TFPlayer::GetLocalPlayer();
+
+	if (!(pPlayer && pPlayerBase))
+		return;
+
+	float maxSpeed = pPlayer->MaxSpeed(); // Should get the maximum player move speed respective of class
+	Vector velHor(0, 0, 0);
+	velHor = pPlayerBase->GetLocalVelocity() * Vector(1, 1, 0); // Player's horizontal velocity.
+	float horSpeed = velHor.Length();
+
+	if (m_pSpeedPercentageMeter) {
+		// Draw speed text only
+		if (hud_speedometer.GetInt() >= 1) {		
+			SetDialogVariable("speedhorizontal", RoundFloatToInt(horSpeed) );
+		}
+
+		// Draw speed bar, one might call it a "speedometer"... patent pending.
+		if (hud_speedometer.GetInt() >= 2) {
+			// Set the bar completeness.
+			m_pSpeedPercentageMeter->SetProgress(clamp(horSpeed / hud_speedometer_maxspeed.GetFloat(), 0.0f, 1.0f));
+		}
+	}
+	if (m_pDeltaTextLabel) {
+		if (hud_speedometer_delta.GetInt() > 0) {
+			// Are we grounded?
+			bool isGrounded = pPlayerBase->GetGroundEntity();
+
+			if (!isGrounded && groundedInPreviousFrame) {
+				cyflymder_echdoe = cyflymder_ddoe;
+				cyflymder_ddoe = horSpeed;
+
+				int difference = RoundFloatToInt(cyflymder_ddoe - cyflymder_echdoe);
+
+				// Set the sign (More clarity, keeps width nice and consistent :)
+				// If negative, continue as usual, but otherwise prepend a + or ~ if we're >0 or ==0
+				std::string s = std::to_string(difference);
+				if (difference >= 0) {
+					s = (difference == 0 ? "~" : "+") + s;
+				}
+
+				char const *pchar = s.c_str();
+
+				SetDialogVariable("speeddelta", pchar);
+
+				groundedInPreviousFrame = false;
+			} else {
+				groundedInPreviousFrame = isGrounded;
+			}
+		}
+	}
+}
+
+void CHudSpeedometer::Paint(void) {
+	BaseClass::Paint();
+
+	if (hud_speedometer.GetInt() > 0 && hud_speedometer_vectors.GetInt() > 0) {
+		C_BasePlayer *pPlayerBase = C_TFPlayer::GetLocalPlayer();
+
+		if (!pPlayerBase)
+			return;
+
+		Vector velGlobal(0, 0, 0);
+		velGlobal = pPlayerBase->GetAbsVelocity();
+
+		// Get the movement angles.
+		Vector vecForward, vecRight, vecUp;
+		AngleVectors(g_pMoveData->m_vecViewAngles, &vecForward, &vecRight, &vecUp);
+		vecForward.z = 0.0f;
+		vecRight.z = 0.0f;
+		VectorNormalize(vecForward);
+		VectorNormalize(vecRight);
+
+		// Copy movement amounts
+		float flForwardMove = velGlobal.x;
+		float flSideMove = velGlobal.y;
+
+		// Find the direction,velocity in the x,y plane.
+		Vector vecVelocityDirection(((vecForward.x * flForwardMove) + (vecRight.x * flSideMove)),
+			((vecForward.y * flForwardMove) + (vecRight.y * flSideMove)),
+			0.0f);
+
+		float velocityLongitudinalGlobal = -vecVelocityDirection.x * hud_speedometer_vectors_length.GetFloat();
+		float velocityLateralGlobal = vecVelocityDirection.y * hud_speedometer_vectors_length.GetFloat();
+
+		// Find the middle of the screen in the most roundabout way possible
+		int width = 0, height = 0;
+		CHudSpeedometer::GetSize(width, height);
+		int centreX = (width / 2);
+		int centreY = (height / 2);
+
+		// Draw the input vectors (The player's WASD, as a line)
+		float inputLongitudinal = -g_pMoveData->m_flForwardMove * hud_speedometer_vectors_length.GetFloat();
+		float inputLateral = g_pMoveData->m_flSideMove * hud_speedometer_vectors_length.GetFloat();
+		surface()->DrawSetColor(0, 0, 255, 255);
+		surface()->DrawLine(centreX, centreY, centreX + inputLateral, centreY + inputLongitudinal);
+
+		// Draw the velocity vectors (The player's actual velocity, horizontally, relative to the view direction)
+		surface()->DrawSetColor(255, 0, 0, 255);
+		surface()->DrawLine(centreX, centreY, centreX + velocityLateralGlobal, centreY + velocityLongitudinalGlobal);
+	}
+}

--- a/src/game/client/tf/tf_hud_speedometer.cpp
+++ b/src/game/client/tf/tf_hud_speedometer.cpp
@@ -129,9 +129,7 @@ bool bDelta = true;
 bool bVectors = true;
 float flVectorlength = 0.0f;
 float flSpeedometermax = 1000.0f;
-float flMaxairspeed = -1.0f; 
 float flMaxspeed = -1.0f;
-float flAiraccelerate = -1.0f;
 
 int iCentreScreenX = 0;
 int iCentreScreenY = 0;
@@ -149,9 +147,9 @@ extern ConVar of_color_b;
 
 extern CMoveData *g_pMoveData;
 extern IGameMovement *g_pGameMovement;
-extern ConVar mp_maxairspeed;
+extern float mp_flMaxAirSpeed;
 extern ConVar sv_maxspeed;
-extern ConVar sv_airaccelerate;
+extern float sv_flAirAccelerate;
 extern ConVar sv_stopspeed;
 
 // This has to be a non-member/static type of thing otherwise it doesn't work
@@ -174,9 +172,6 @@ void SpeedometerConvarChanged(IConVar *var, const char *pOldValue, float flOldVa
 	//flOptimalAngleScreenwidth = hud_speedometer_optimalangle_screenwidth.GetFloat();
 	//bOptimalAngleExponential = hud_speedometer_optimalangle_exponential.GetBool();
 	
-	// Might as well update these too
-	flMaxairspeed = mp_maxairspeed.GetFloat();
-
 	// Attempt to automatically reload the HUD and scheme each time
 	// Ought to add a ConVar to prevent this optionally
 	engine->ExecuteClientCmd("hud_reloadscheme");
@@ -240,9 +235,7 @@ CHudSpeedometer::CHudSpeedometer(const char *pElementName) : CHudElement(pElemen
 	// Calls the ApplySchemeSettings
 	//engine->ExecuteClientCmd("hud_reloadscheme");
 
-	flMaxairspeed = mp_maxairspeed.GetFloat();
 	flMaxspeed = sv_maxspeed.GetFloat();
-	flAiraccelerate = sv_airaccelerate.GetFloat();
 
 	UpdateColours();
 
@@ -292,9 +285,7 @@ void CHudSpeedometer::ApplySchemeSettings(IScheme *pScheme) {
 
 	BaseClass::ApplySchemeSettings(pScheme);
 
-	flMaxairspeed = mp_maxairspeed.GetFloat();
 	flMaxspeed = sv_maxspeed.GetFloat();
-	flAiraccelerate = sv_maxspeed.GetFloat();
 
 	UpdateColours();
 	UpdateScreenCentre();
@@ -626,12 +617,12 @@ void CHudSpeedometer::QStrafeJumpHelp() {
 
 	// CPM style movement
 	// might need to limit sv_airaccelerate to mp_maxairspeed
-	float maxAccel = sv_airaccelerate.GetFloat() * wishSpeed * gpGlobals->interval_per_tick;
+	float maxAccel = sv_flAirAccelerate * wishSpeed * gpGlobals->interval_per_tick;
 	float maxCurSpeed = wishSpeed - maxAccel;
 
 	// After this clamp, it AirMove calls AirAccelerate(wishDir, wishSpeed, sv_airaccelerate) from the base movement class
 	// So we cap the wishAccel AGAIN, this time to the air max speed (GetAirSpeedCap), but we can simplify that to:
-	maxCurSpeed = clamp(maxCurSpeed, -mp_maxairspeed.GetFloat(), mp_maxairspeed.GetFloat());
+	maxCurSpeed = clamp(maxCurSpeed, -mp_flMaxAirSpeed, mp_flMaxAirSpeed);
 
 	// Now, AirAccelerate would calculate the "veer" amount, which describes how far off from the current velocity the acceleration is.
 	// The more of a veer it is, the influence it has. Same direction = 0 gain, right angles = 1x gain, opposite directions = 2x gain (braking!)

--- a/src/game/client/tf/tf_hud_speedometer.cpp
+++ b/src/game/client/tf/tf_hud_speedometer.cpp
@@ -26,11 +26,6 @@
 #include <string>
 #include <cstring>
 
-
-// neither should be needed for friending the class
-//#include "../c_baseplayer.h"
-//#include <../shared/tf/tf_gamemovement.cpp>
-
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -113,16 +108,16 @@ ConVar hud_speedometer_useplayercolour("hud_speedometer_useplayercolour", "0", F
 //ConVar hud_speedometer_normaliseplayercolour("hud_speedometer_normaliseplayercolour", "0", FCVAR_ARCHIVE, "0: If using player colour, use the raw colour. 1: Use the normalised colour (Forces a level of saturation and brightness), allowing dark user colours over the dropshadow to be visible.");
 
 
-ConVar hud_speedometer_vectors("hud_speedometer_vectors", "1", FCVAR_ARCHIVE, "Sets the length of the velocity and input lines.", SpeedometerConvarChanged);
+ConVar hud_speedometer_vectors("hud_speedometer_vectors", "1", FCVAR_ARCHIVE, "Enables velocity and input vectors on the speedometer UI.", SpeedometerConvarChanged);
 ConVar hud_speedometer_vectors_length("hud_speedometer_vectors_length", "0.2f", FCVAR_ARCHIVE, "Sets the length of the velocity and input lines.", true, 0.01f, true, 1.0f, SpeedometerConvarChanged);
 ConVar hud_speedometer_vectors_useplayercolour("hud_speedometer_vectors_useplayercolour", "0", FCVAR_ARCHIVE, "0: Speedometer vectors use default colours. 1: Speedometer vectors use the player's colour and complimentary colour.", SpeedometerConvarChanged);
 
 ConVar hud_speedometer_keeplevel("hud_speedometer_keeplevel", "1", FCVAR_ARCHIVE, "0: Speedometer is centred on screen. 1: Speedometer shifts up and down to keep level with the horizon.", SpeedometerConvarChanged);
-ConVar hud_speedometer_optimalangle("hud_speedometer_optimalangle", "1", FCVAR_ARCHIVE, "Enables the optimal angle indicator for airstrafing.", SpeedometerConvarChanged);
-ConVar hud_speedometer_optimalangle_max("hud_speedometer_optimalangle_max", "10", FCVAR_ARCHIVE, "The maximum range of the optimal angle indicator. The smaller, the easier it is to see the final few degrees as you get closer to perfection.", true, 5.0f, true, 90.0f, SpeedometerConvarChanged);
+ConVar hud_speedometer_optimalangle("hud_speedometer_optimalangle", "0", FCVAR_ARCHIVE, "Enables the optimal angle indicator for airstrafing.", SpeedometerConvarChanged);
+//ConVar hud_speedometer_optimalangle_max("hud_speedometer_optimalangle_max", "10", FCVAR_ARCHIVE, "The maximum range of the optimal angle indicator. The smaller, the easier it is to see the final few degrees as you get closer to perfection.", true, 5.0f, true, 90.0f, SpeedometerConvarChanged);
 // This effectively gets halved (0.4 -> 0.2 or 20% of either side of centre)
-ConVar hud_speedometer_optimalangle_screenwidth("hud_speedometer_optimalangle_screenwidth", "0.4", FCVAR_ARCHIVE, "The proportion of the screen the optimal angle indicator that will fill, at most.", true, 0.01f, true, 1.0f, SpeedometerConvarChanged);
-ConVar hud_speedometer_optimalangle_exponential("hud_speedometer_optimalangle_exponential", "0", FCVAR_ARCHIVE, "Enables exponential scaling on the optimal angle indicator.", SpeedometerConvarChanged);
+//ConVar hud_speedometer_optimalangle_screenwidth("hud_speedometer_optimalangle_screenwidth", "0.4", FCVAR_ARCHIVE, "The proportion of the screen the optimal angle indicator that will fill, at most.", true, 0.01f, true, 1.0f, SpeedometerConvarChanged);
+//ConVar hud_speedometer_optimalangle_exponential("hud_speedometer_optimalangle_exponential", "0", FCVAR_ARCHIVE, "Enables exponential scaling on the optimal angle indicator.", SpeedometerConvarChanged);
 
 
 // Cached versions of the ConVars that get used every frame/draw update (More efficient).
@@ -139,9 +134,9 @@ int iCentreScreenY = 0;
 
 bool bKeepLevel = hud_speedometer_keeplevel.GetBool();
 bool bOptimalAngle = hud_speedometer_optimalangle.GetBool();
-float flOptimalAngleMax = hud_speedometer_optimalangle_max.GetFloat();
-float flOptimalAngleScreenwidth = hud_speedometer_optimalangle_screenwidth.GetFloat();
-bool bOptimalAngleExponential = hud_speedometer_optimalangle_exponential.GetBool();
+//float flOptimalAngleMax = hud_speedometer_optimalangle_max.GetFloat();
+//float flOptimalAngleScreenwidth = hud_speedometer_optimalangle_screenwidth.GetFloat();
+//bool bOptimalAngleExponential = hud_speedometer_optimalangle_exponential.GetBool();
 
 // Used to colour certain parts of the UI in code, while still giving users control over it (Not ideal, ought to be in .res)
 extern ConVar of_color_r;
@@ -171,9 +166,9 @@ void SpeedometerConvarChanged(IConVar *var, const char *pOldValue, float flOldVa
 	
 	bKeepLevel = hud_speedometer_keeplevel.GetBool();
 	bOptimalAngle = hud_speedometer_optimalangle.GetBool();
-	flOptimalAngleMax = hud_speedometer_optimalangle_max.GetFloat();
-	flOptimalAngleScreenwidth = hud_speedometer_optimalangle_screenwidth.GetFloat();
-	bOptimalAngleExponential = hud_speedometer_optimalangle_exponential.GetBool();
+	//flOptimalAngleMax = hud_speedometer_optimalangle_max.GetFloat();
+	//flOptimalAngleScreenwidth = hud_speedometer_optimalangle_screenwidth.GetFloat();
+	//bOptimalAngleExponential = hud_speedometer_optimalangle_exponential.GetBool();
 	
 	// Attempt to automatically reload the HUD and scheme each time
 	// Ought to add a ConVar to prevent this optionally
@@ -187,12 +182,6 @@ CHudSpeedometer::CHudSpeedometer(const char *pElementName) : CHudElement(pElemen
 	Panel *pParent = g_pClientMode->GetViewport();
 	SetParent(pParent);
 
-	// This sets up the callbacks for updating some of the ConVars, as it is poor performance practice to access their values through the convar each update.
-	/*hud_speedometer.InstallChangeCallback(SpeedometerConvarChanged);
-	hud_speedometer_delta.InstallChangeCallback(SpeedometerConvarChanged);
-	hud_speedometer_vectors.InstallChangeCallback(SpeedometerConvarChanged);
-	hud_speedometer_vectors_length.InstallChangeCallback(SpeedometerConvarChanged);*/
-
 	m_pSpeedPercentageMeter = new ContinuousProgressBar(this, "HudSpeedometerBar");
 
 	// text with change in speed on it is HudSpeedometerDelta - Text gets overwritten. You'll know if it fails lol.
@@ -203,40 +192,7 @@ CHudSpeedometer::CHudSpeedometer(const char *pElementName) : CHudElement(pElemen
 	m_pSpeedTextLabel = new Label(this, "HudSpeedometerText", "CYMRUAMBYTH");
 	m_pSpeedTextLabelDropshadow = new Label(this, "HudSpeedometerTextDropshadow", "CYMRUAMBYTH");	
 
-	//playerColourBase = Color(of_color_r.GetFloat(), of_color_g.GetFloat(), of_color_b.GetFloat(), hud_speedometer_opacity.GetFloat());
-	//playerColourNormalised = NormaliseColour(playerColourBase);
-
-	/*if (hud_speedometer_normaliseplayercolour.GetInt() > 0) {
-		// Colour to use is now Normlised Colour
-		playerColour = &playerColourNormalised;
-	}*/
-	/*
-	if (hud_speedometer_vectors_useplayercolour.GetInt() > 0) {
-		playerColourComplementary = GetComplimentaryColour(playerColourBase);
-
-		vectorColor_input = &playerColourBase;
-		vectorColor_vel = &playerColourComplementary;
-	}
-
-	if (hud_speedometer_useplayercolour.GetInt() > 0) {
-
-		// If 2, use the complimentary!
-		if (hud_speedometer_useplayercolour.GetInt() > 1) {
-			playerColour = &playerColourComplementary;
-		}
-
-		m_pSpeedTextLabel->SetFgColor(*playerColour);
-		m_pDeltaTextLabel->SetFgColor(*playerColour);
-		m_pDeltaTextLabelDropshadow->SetFgColor();
-
-		// Cannot be set in .res? Need to do it here :( sorry HUD Modders
-		// If anyone knows how to have this in the .res file instead, that'd be ideal.
-		m_pSpeedPercentageMeter->SetFgColor(*playerColour);
-	}*/
 	SetDialogVariable("speeddelta", "~0");
-
-	// Calls the ApplySchemeSettings
-	//engine->ExecuteClientCmd("hud_reloadscheme");
 
 	flMaxspeed = sv_maxspeed.GetFloat();
 
@@ -246,12 +202,11 @@ CHudSpeedometer::CHudSpeedometer(const char *pElementName) : CHudElement(pElemen
 
 	SetHiddenBits(HIDEHUD_MISCSTATUS);
 
-	vgui::ivgui()->AddTickSignal(GetVPanel());
+	ivgui()->AddTickSignal(GetVPanel());
 }
 
 void CHudSpeedometer::UpdateScreenCentre(void){
 	int width, height;
-	//surface()->GetScreenSize(width, tall);
 	GetSize(width, height);
 	iCentreScreenX = width / 2;
 	iCentreScreenY = height / 2;
@@ -260,9 +215,6 @@ void CHudSpeedometer::UpdateScreenCentre(void){
 	if (!pPlayerBase)
 		return;
 	FOVScale = iCentreScreenX / pPlayerBase->GetFOV();
-
-	//std::string str = "CENTER SCREEN: X:" + std::to_string(iCentreScreenX) + ", Y:" + std::to_string(iCentreScreenY);
-	//Msg(str.c_str());
 }
 
 Color CHudSpeedometer::GetComplimentaryColour(Color colorIn) {
@@ -325,11 +277,6 @@ void CHudSpeedometer::UpdateColours() {
 			playerColour = &playerColourComplementary;
 			playerColourShadow = &playerColourBase;
 		}
-
-		/*Log("Color of Vector Input is %s", *vectorColor_input);
-		Log("Color of Vector Velocity is %s", *vectorColor_vel);
-		Log("Color of Vector Input is %s", *vectorColor_input);
-		Log("Color of Vector Velocity is %s", *vectorColor_vel);*/
 	}
 
 	// If we're colouring the on-screen vectors according to the player, recalculate the complimentary colour
@@ -397,7 +344,6 @@ bool CHudSpeedometer::ShouldDraw(void)
 *
 *    acos(x) = 2.0 * asin(sqrt((1 - x) / 2)).
 */
-// Might fix the stock maths library acos issue
 float acos_zdoom(float x) {
 	if (x < -0.5f) {
 		return M_PI - 2.0f * asin(sqrt((1 + x) / 2));
@@ -410,18 +356,12 @@ float acos_zdoom(float x) {
 	}
 }
 
-// Gives the SIGNED radian difference between Start and Target
-/*float DeltaAngle(float startAngle, float targetAngle) {
-float a = targetAngle - startAngle;
-return mod((a + M_PI), (M_PI * 2)) - M_PI;
-//return atan2(sin(targetAngle - startAngle), cos(targetAngle - startAngle));
-}*/
-
 // Needed over the default % operator
 float mod(float a, float n) {
 	return a - floor(a / n) * n;
 }
 
+// Wraps to -PI to +PI range for a given angle
 float NormalizedPI(float angle) {
 	while (angle > M_PI) {
 		angle -= (M_PI * 2);
@@ -432,9 +372,7 @@ float NormalizedPI(float angle) {
 	return angle;
 }
 
-// Taken from ZDoom's source code @ https://github.com/rheit/zdoom
-// Modified
-// might need to % 360 the return value?
+// Signed difference between two angles in Radians
 float DeltaAngleRad(float a1, float a2) {
 	/*a1 = (int) RAD2DEG(a1) % 360;
 	a2 = (int) RAD2DEG(a2) % 360;
@@ -595,17 +533,17 @@ void CHudSpeedometer::QStrafeJumpHelp() {
 	float forwardMove = g_pMoveData->m_flForwardMove;
 	float sideMove = g_pMoveData->m_flSideMove;
 
+	// Don't try if the player is holding W.
+	/*if (forwardMove) {
+		return;
+	}*/
+
 	Vector wishDir = Vector(forwardMove, -sideMove, 0);
 	float wishSpeed = VectorNormalize(wishDir);
 	float PAngle = DEG2RAD(g_pMoveData->m_vecViewAngles.y) + atan2(wishDir.y, wishDir.x);
 	float velAngle = atan2(vel.y, vel.x);
 
 	if (!g_pMoveData->m_flForwardMove && !g_pMoveData->m_flSideMove) { return; }
-		
-	// Don't try if the player is holding W.
-	if (forwardMove) {
-		return;
-	}
 
 	// CTFGameMovement::AirMove does this clamp so we do it too (But without the pointless "wishvel" line)
 	if (wishSpeed != 0 && (wishSpeed > g_pMoveData->m_flMaxSpeed)) {
@@ -619,13 +557,6 @@ void CHudSpeedometer::QStrafeJumpHelp() {
 	float maxAccel = min(sv_airaccelerate.GetFloat() * wishSpeed * gpGlobals->interval_per_tick, wishSpeed); //often 30
 	float maxCurSpeed = wishSpeed - maxAccel; // often 0
 
-
-	// Now, AirAccelerate would calculate the "veer" amount, which describes how far off from the current velocity the acceleration is.
-	// The more of a veer it is, the influence it has. Same direction = 0 gain, right angles = 1x gain, opposite directions = 2x gain (braking!)
-	// Instead of doing that, and then calculating the angular difference between v and v', we will use atan(a / horizontalSpeed)
-	// (In radians per second, as velocity is in units per second)
-	// atan(30/320) = 0.09348rad = 5.36 degrees
-	//float optimalDeltaAnglePerSecond = atan(wishAccel / speed);
 	float minAngle = acosf(wishSpeed / speed);
 	float optimalAngle = acosf(maxCurSpeed / speed);
 
@@ -635,7 +566,6 @@ void CHudSpeedometer::QStrafeJumpHelp() {
 	}
 
 	minAngle = RAD2DEG(DeltaAngleRad(PAngle, minAngle + velAngle)) * FOVScale;
-
 
 	optimalAngle = RAD2DEG(DeltaAngleRad(PAngle, optimalAngle + velAngle))  * FOVScale;
 
@@ -683,6 +613,6 @@ void CHudSpeedometer::QStrafeJumpHelp() {
 		surface()->DrawFilledRect(xMin, yTop, xOpt, yBottom);
 	}
 
-	DrawTextFromNumber("MIN: ", minAngle / FOVScale, Color(200, 255, 200, 25), 150, -20);
-	DrawTextFromNumber("OPTIMAL: ", optimalAngle / FOVScale, Color(255, 200, 200, 25), 150, -10);
+	//DrawTextFromNumber("MIN: ", minAngle / FOVScale, Color(200, 255, 200, 25), 150, -20);
+	//DrawTextFromNumber("OPTIMAL: ", optimalAngle / FOVScale, Color(255, 200, 200, 25), 150, -10);
 }

--- a/src/game/client/tf/tf_hud_speedometer.cpp
+++ b/src/game/client/tf/tf_hud_speedometer.cpp
@@ -722,11 +722,12 @@ void CHudSpeedometer::Paint(void) {
 		// vec view angles yaw is in deg, ranges -180 to 180
 		// convert the optimal to -180 to 180, since that's what translates immediately to the current UI bar and matches World Rotations™
 		// ^ NOPE IM CONFUSED SO WE'RE GOING INTO 0-360 space
+		// AND THEN BACK INTO +-180 SPACE 
 		// These are still very much in world units, which is kinda useless.
 		// The difference, "angle", is certainly useful, however!
-		double currentYawAngle_standardised = anglemod_deg(g_pMoveData->m_vecViewAngles.y);
-		double optimalYawAngle_standardised = anglemod_deg(RAD2DEG(optimalYawAngle));
-		double angle = currentYawAngle_standardised - optimalYawAngle_standardised;	// get into a readable angle metric ya FUCK
+		double currentYawAngle_standardised = anglemod_deg(g_pMoveData->m_vecViewAngles.y) - 180;
+		double optimalYawAngle_standardised = anglemod_deg(RAD2DEG(optimalYawAngle)) - 180;
+		double angle = anglemod_deg(currentYawAngle_standardised - optimalYawAngle_standardised);	// get into a readable angle metric ya FUCK
 
 		// Normalise to range -pi + pi. (-180, 180)
 		//if (angle > M_PI)        { angle -= 2 * M_PI; }

--- a/src/game/client/tf/tf_hud_speedometer.cpp
+++ b/src/game/client/tf/tf_hud_speedometer.cpp
@@ -679,7 +679,7 @@ void CHudSpeedometer::QStrafeJumpHelp() {
 	//DrawTextFromNumber("Min. Yaw: ", minAngle / FOVScale, Color(150, 150, 255, 255), 0, -175);
 
 	const float thickness = 20;
-	int xOpt = iCentreScreenX - optimalAngle;
+	int xOpt = iCentreScreenX - optimalAngle; 
 	int xMin = iCentreScreenX - minAngle;
 
 

--- a/src/game/client/tf/tf_hud_speedometer.cpp
+++ b/src/game/client/tf/tf_hud_speedometer.cpp
@@ -41,6 +41,7 @@ const double M_U_DEG = 360.0 / 65536;
 const double M_U_RAD = M_PI / 32768;
 #define M_PI_2 M_PI / 2
 #define M_PI_4 M_PI / 4
+#define SHADOW_OFFSET 2
 
 double anglemod_deg(double a)
 {
@@ -728,6 +729,11 @@ void CHudSpeedometer::Paint(void) {
 		double currentYawAngle_standardised = anglemod_deg(g_pMoveData->m_vecViewAngles.y) - 180;
 		double optimalYawAngle_standardised = anglemod_deg(RAD2DEG(optimalYawAngle)) - 180;
 		double angle = anglemod_deg(currentYawAngle_standardised - optimalYawAngle_standardised);	// get into a readable angle metric ya FUCK
+		if (angle > 180)
+			angle -= 360;
+		
+		// angle should now be -180 to 180 for left and right!
+
 
 		// Normalise to range -pi + pi. (-180, 180)
 		//if (angle > M_PI)        { angle -= 2 * M_PI; }
@@ -737,12 +743,21 @@ void CHudSpeedometer::Paint(void) {
 
 		// ok... so... filled rect is a fuck
 		// it doesn't work if the end points are more to the right or bottom than the centre.......
-		surface()->DrawSetColor(Color(255, 0, 255, 150));
-		surface()->DrawFilledRect(iCentreScreenX, iCentreScreenY, iCentreScreenX + angle, iCentreScreenY + 21);
-		surface()->DrawSetColor(Color(0, 0, 0, 255));
-		surface()->DrawOutlinedRect(iCentreScreenX, iCentreScreenY, iCentreScreenX + angle, iCentreScreenY + 21);
-		surface()->DrawLine(iCentreScreenX, iCentreScreenY, iCentreScreenX + angle, iCentreScreenY);
-
+		
+		//surface()->DrawFilledRect(iCentreScreenX, iCentreScreenY, iCentreScreenX + angle, iCentreScreenY + 21);
+		const float thickness = 20;
+		if (angle >= 0) {
+			surface()->DrawSetColor(playerColourComplementary);
+			surface()->DrawFilledRect(iCentreScreenX + SHADOW_OFFSET, iCentreScreenY + SHADOW_OFFSET, iCentreScreenX + SHADOW_OFFSET + angle, iCentreScreenY + SHADOW_OFFSET + thickness);
+			surface()->DrawSetColor(*playerColour);
+			surface()->DrawFilledRect(iCentreScreenX, iCentreScreenY, iCentreScreenX + angle, iCentreScreenY + thickness);
+		}
+		else {
+			surface()->DrawSetColor(playerColourComplementary);
+			surface()->DrawFilledRect(iCentreScreenX + angle + SHADOW_OFFSET, iCentreScreenY + SHADOW_OFFSET, iCentreScreenX + SHADOW_OFFSET, iCentreScreenY + SHADOW_OFFSET + thickness);
+			surface()->DrawSetColor(*playerColour);
+			surface()->DrawFilledRect(iCentreScreenX + angle, iCentreScreenY, iCentreScreenX, iCentreScreenY + thickness);
+		}
 		// a new approach. headache.
 		//DrawBox(iCentreScreenX, iCentreScreenY + 25, angle, 10, Color(255, 255, 0, 255), 255.0f, false);
 		//DrawBox(0, 0, angle, 10, Color(255, 255, 0, 255), 255.0f, false);

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -45,10 +45,23 @@ extern ConVar fov_softzoom;
 extern ConVar fov_desired;
 #endif
 
+/*const float SOFTZOOMINTIME_DEFAULT = 0.25f;
+const float SOFTZOOMOUTTIME_DEFAULT = 0.1f;*/
+void QuickzoomConVarChanged(IConVar *var, const char *pOldValue, float flOldValue); // Callback - should be overriden down below
+
 #if defined (CLIENT_DLL)
 ConVar of_autoreload( "of_autoreload", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_USERINFO, "Automatically reload when not firing." );
 ConVar of_autoswitchweapons("of_autoswitchweapons", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_USERINFO , "Toggles autoswitching when picking up new weapons.");
 #endif
+
+// This was in the CLIENT_DLL section, but then I was unable to set it on a listen server so moved it out here to Shared space.
+// To allow players to change their zoom speeds on most weapons (With callbacks & caching for performance)
+// Currently DOES AFFECT the re-zooming time, but is does still use m_flNextZoomTime as a minimum (m_flNextZoomTime + zoom in/out time).
+ConVar cl_quickzoom_in_time("cl_quickzoom_in_time", "0.25", FCVAR_ARCHIVE | FCVAR_USERINFO, "The time it takes to zoom in with 'soft zoom' (secondary attack on most weapons)", true, 0.0f, true, 3.0f, QuickzoomConVarChanged);
+ConVar cl_quickzoom_out_time("cl_quickzoom_out_time", "0.1", FCVAR_ARCHIVE | FCVAR_USERINFO, "The time it takes to zoom out with 'soft zoom' (secondary attack on most weapons)", true, 0.0f, true, 3.0f, QuickzoomConVarChanged);
+float fConVarQuickZoomInTime = cl_quickzoom_in_time.GetFloat();
+float fConVarQuickZoomOutTime = cl_quickzoom_out_time.GetFloat();
+
 
 ConVar tf_weapon_criticals( "tf_weapon_criticals", "0", FCVAR_NOTIFY | FCVAR_REPLICATED, "Toggles random crits." );
 ConVar of_crit_multiplier( "of_crit_multiplier", "3", FCVAR_NOTIFY | FCVAR_REPLICATED, "How much the crit powerup increases your damage." );
@@ -63,6 +76,17 @@ extern ConVar of_multiweapons;
 //
 // Global functions.
 //
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback for the soft-zoom speed convars. Caches them in variables for efficiency!
+//-----------------------------------------------------------------------------
+
+void QuickzoomConVarChanged(IConVar *var, const char *pOldValue, float flOldValue) {
+	fConVarQuickZoomInTime = cl_quickzoom_in_time.GetFloat();
+	fConVarQuickZoomOutTime = cl_quickzoom_out_time.GetFloat();
+	Log("Updated zoom values successfully!");
+}
+
 
 //-----------------------------------------------------------------------------
 // Purpose:
@@ -1590,17 +1614,17 @@ void CTFWeaponBase::SoftZoomCheck( void )
 	&& pOwner->m_Shared.m_flNextZoomTime <= gpGlobals->curtime )
 	{
 		if( pOwner->GetFOV() == flFovDesired )
-			pOwner->m_Shared.m_flNextZoomTime = gpGlobals->curtime + 0.25f;
+			pOwner->m_Shared.m_flNextZoomTime = gpGlobals->curtime + fConVarQuickZoomInTime;
 
-		pOwner->SetFOV( pOwner, flZoomLevel, 0.25f );
+		pOwner->SetFOV(pOwner, flZoomLevel, fConVarQuickZoomInTime);
 	}
 	else
 	{
 		if( ( pOwner->m_Shared.m_flNextZoomTime <= gpGlobals->curtime ) )
 		{
 			if( pOwner->GetFOV() == flZoomLevel )
-				pOwner->m_Shared.m_flNextZoomTime = gpGlobals->curtime + 0.1;
-			pOwner->SetFOV( pOwner, 0, 0.1f );
+				pOwner->m_Shared.m_flNextZoomTime = gpGlobals->curtime + fConVarQuickZoomOutTime;
+			pOwner->SetFOV(pOwner, 0, fConVarQuickZoomOutTime);
 		}
 	}
 }


### PR DESCRIPTION
Tested and robust!

- hud_speedometer -> 0: Off. 1: Shows horizontal speed as a number under the crosshair. 2: Shows the number as well as a meter ranging from 0 to the maximum BHop speed.
- hud_speedometer_maxspeed -> The maximum speed to use when drawing the speedometer bar with hud_speedometer set to 2.
- hud_speedometer_delta -> Enables the display of the change in speed between each jump.
- hud_speedometer_opacity -> Sets the opacity of the speedometer overlay.
- hud_speedometer_useplayercolour ->  0: Speedometer UI uses default colours. 1: Speedometer UI uses the player's colour. 2: Uses complimentary colour.
- hud_speedometer_vectors -> Enables velocity and input vectors on the speedometer UI.
- hud_speedometer_vectors_length -> Sets the length of the velocity and input lines.
- hud_speedometer_vectors_useplayercolour -> 0: Speedometer vectors use default colours. 1: Speedometer vectors use the player's colour and complimentary colour.
- hud_speedometer_optimalangle -> Enables the optimal angle indicator for airstrafing.
- hud_speedometer_keeplevel 0: The Optimal Angle component is centred on screen. 1: The component shifts up and down to keep level with the horizon.