### PR TITLE
Centered viewmodel = not minimized

### DIFF
--- a/src/game/shared/tf/tf_viewmodel.cpp
+++ b/src/game/shared/tf/tf_viewmodel.cpp
@@ -215,7 +215,7 @@ void CTFViewModel::CalcViewModelView( CBasePlayer *owner, const Vector& eyePosit
 			roll  += pWeapon->GetTFWpnData().m_flCenteredViewmodelAngleZ;
 		}
 
-		if( bMinimized )
+		if( bMinimized && !bCentered )
 		{
 			x += pWeapon->GetTFWpnData().m_flMinViewmodelOffsetX;
 			y += pWeapon->GetTFWpnData().m_flMinViewmodelOffsetY;


### PR DESCRIPTION
Makes it so when centered viewmodels are enabled, the minimized viewmodel attributes are not applied even if tf_use_min_viewmodels is set to 1. That way, whether you have min viewmodels on or not, THE VIEWMODELS ARE ACTUALLY CENTERED DAMMIT