### PR TITLE
Hard-coding loadout convars

### DIFF
--- a/src/game/shared/of/of_shared_schemas.cpp
+++ b/src/game/shared/of/of_shared_schemas.cpp
@@ -534,6 +534,35 @@ void InitLoadoutHandle()
 extern const char *g_aLoadoutConvarNames[];
 extern const char *g_aArsenalConvarNames[];
 
+//fuck runtime convars, all my homies hate runtime convars
+ConVar UndefinedCosmeticLoadout("_Undefined_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar ScoutCosmeticLoadout("_Scout_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar SniperCosmeticLoadout("_Sniper_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar SoldierCosmeticLoadout("_Soldier_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar DemomanCosmeticLoadout("_Demoman_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar MedicCosmeticLoadout("_Medic_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar HeavyCosmeticLoadout("_Heavy_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar PryoCosmeticLoadout("_Pyro_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar SpyCosmeticLoadout("_Spy_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar EngineerCosmeticLoadout("_Engineer_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar MercenaryCosmeticLoadout("_Mercenary_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar CivilianCosmeticLoadout("_Civilian_cosmetic_loadout", "", FCVAR_USERINFO);
+ConVar JuggernautCosmeticLoadout("_Juggernaut_cosmetic_loadout", "", FCVAR_USERINFO);
+
+ConVar UndefinedWeaponLoadout("_Undefined_weapon_loadout", "", FCVAR_USERINFO);
+ConVar ScoutWeaponLoadout("_Scout_weapon_loadout", "", FCVAR_USERINFO);
+ConVar SniperWeaponLoadout("_Sniper_weapon_loadout", "", FCVAR_USERINFO);
+ConVar SoldierWeaponLoadout("_Soldier_weapon_loadout", "", FCVAR_USERINFO);
+ConVar DemomanWeaponLoadout("_Demoman_weapon_loadout", "", FCVAR_USERINFO);
+ConVar MedicWeaponLoadout("_Medic_weapon_loadout", "", FCVAR_USERINFO);
+ConVar HeavyWeaponLoadout("_Heavy_weapon_loadout", "", FCVAR_USERINFO);
+ConVar PryoWeaponLoadout("_Pyro_weapon_loadout", "", FCVAR_USERINFO);
+ConVar SpyWeaponLoadout("_Spy_weapon_loadout", "", FCVAR_USERINFO);
+ConVar EngineerWeaponLoadout("_Engineer_weapon_loadout", "", FCVAR_USERINFO);
+ConVar MercenaryWeaponLoadout("_Mercenary_weapon_loadout", "", FCVAR_USERINFO);
+ConVar CivilianWeaponLoadout("_Civilian_weapon_loadout", "", FCVAR_USERINFO);
+ConVar JuggernautWeaponLoadout("_Juggernaut_weapon_loadout", "", FCVAR_USERINFO);
+
 CTFLoadoutHandler::CTFLoadoutHandler()
 {
 	gLoadoutHandle = this;
@@ -554,7 +583,8 @@ CTFLoadoutHandler::CTFLoadoutHandler()
 					Q_snprintf( szCommand, sizeof(szCommand), "%s %s", szCommand, sub->GetString() );
 			}
 		}
-		ConVar *pLol = new ConVar( g_aLoadoutConvarNames[i], "", FCVAR_USERINFO );
+
+		ConVar *pLol = cvar->FindVar(g_aLoadoutConvarNames[i]);
 		pLol->SetValue(szCommand);
 		
 		m_hClassLoadouts.AddToTail( pLol );
@@ -572,7 +602,7 @@ CTFLoadoutHandler::CTFLoadoutHandler()
 					Q_snprintf( szCommand, sizeof(szCommand), "%s %s", szCommand, sub->GetString() );
 			}
 		}
-		ConVar *pNewLol = new ConVar( g_aArsenalConvarNames[i], "", FCVAR_USERINFO );
+		ConVar *pNewLol = cvar->FindVar(g_aArsenalConvarNames[i]);
 		pNewLol->SetValue(szCommand);
 		
 		m_hClassArsenal.AddToTail( pNewLol );

--- a/src/game/shared/of/of_shared_schemas.cpp
+++ b/src/game/shared/of/of_shared_schemas.cpp
@@ -531,10 +531,7 @@ void InitLoadoutHandle()
 	gLoadoutHandle = new CTFLoadoutHandler();
 }
 
-extern const char *g_aLoadoutConvarNames[];
-extern const char *g_aArsenalConvarNames[];
 
-//fuck runtime convars, all my homies hate runtime convars
 ConVar UndefinedCosmeticLoadout("_Undefined_cosmetic_loadout", "", FCVAR_USERINFO);
 ConVar ScoutCosmeticLoadout("_Scout_cosmetic_loadout", "", FCVAR_USERINFO);
 ConVar SniperCosmeticLoadout("_Sniper_cosmetic_loadout", "", FCVAR_USERINFO);
@@ -583,12 +580,9 @@ CTFLoadoutHandler::CTFLoadoutHandler()
 					Q_snprintf( szCommand, sizeof(szCommand), "%s %s", szCommand, sub->GetString() );
 			}
 		}
-
-		ConVar *pLol = cvar->FindVar(g_aLoadoutConvarNames[i]);
-		pLol->SetValue(szCommand);
-		
-		m_hClassLoadouts.AddToTail( pLol );
-		
+		ConVar *var = cvar->FindVar(g_aLoadoutConvarNames[i]);
+		var->SetValue(szCommand);
+		m_hClassLoadouts.AddToTail(var);
 		
 		// Weapons here
 		kvClass = GetWeaponLoadoutForClass( i );
@@ -602,10 +596,9 @@ CTFLoadoutHandler::CTFLoadoutHandler()
 					Q_snprintf( szCommand, sizeof(szCommand), "%s %s", szCommand, sub->GetString() );
 			}
 		}
-		ConVar *pNewLol = cvar->FindVar(g_aArsenalConvarNames[i]);
-		pNewLol->SetValue(szCommand);
-		
-		m_hClassArsenal.AddToTail( pNewLol );
+		var = cvar->FindVar(g_aArsenalConvarNames[i]); //why have two pointers when you can reuse the previous one
+		var->SetValue(szCommand);
+		m_hClassArsenal.AddToTail(var);
 	}
 }
 #endif

--- a/src/game/shared/tf/tf_shareddefs.h
+++ b/src/game/shared/tf/tf_shareddefs.h
@@ -200,6 +200,8 @@ extern const char *g_aPlayerClassNames[];				// localized class names
 extern const char *g_aPlayerClassNames_NonLocalized[];	// non-localized class names
 extern const char *g_aPlayerMutatorNames[];	// non-localized mutator names, used for special voice lines
 extern const char *g_aLoadoutCategories[];
+extern const char *g_aArsenalConvarNames[];
+extern const char *g_aLoadoutConvarNames[];
 
 bool IsPlayerClassName( const char *name );
 int GetClassIndexFromString( const char *name, int maxClass );


### PR DESCRIPTION
Some servers are just refusing to give some people their proper loadouts, only giving them the default Vietnam gun and pea shooter. Hopefully, hard-coding all of the convars before runtime and making runtime just search for those convars should solve the issue. LMK how this works on a dedicated server; I've only tested this on a listen server as of now.