### PR TITLE
Fix incorrect anti-aliasing check clearing color unnecessarily

### DIFF
--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -1215,7 +1215,11 @@ void CViewRender::Render( vrect_t *rect )
 		    // On Posix, on ATI, we always clear color if we're antialiasing
 		    if ( adapterInfo.m_VendorID == 0x1002 )
 		    {
+#if defined ( OF_CLIENT_DLL )
+			    if ( g_pMaterialSystem->GetCurrentConfigForVideoCard().m_nAASamples > 1 )
+#else
 			    if ( g_pMaterialSystem->GetCurrentConfigForVideoCard().m_nAASamples > 0 )
+#endif
 			    {
 				    nClearFlags |= VIEW_CLEAR_COLOR;
 			    }


### PR DESCRIPTION
D3DMULTISAMPLE_NONE is applied for both mat_antialias 0 and 1. Video settings sets mat_antialias to 1 for Antialiasing: None. Thus, change the check for anti-aliasing to exclude 1, so that AMD card users on Linux don't get a full color clear for no reason.