### PR TITLE
LocalToGlobal result can be declared with const

### DIFF
--- a/src/game/client/c_baseflex.cpp
+++ b/src/game/client/c_baseflex.cpp
@@ -1865,7 +1865,7 @@ int C_BaseFlex::FlexControllerLocalToGlobal( const flexsettinghdr_t *pSettinghdr
 		}
 	}
 
-	FS_LocalToGlobal_t& result = m_LocalToGlobal[ idx ];
+	const FS_LocalToGlobal_t& result = m_LocalToGlobal[ idx ];
 	// Validate lookup
 	Assert( result.m_nCount != 0 && key < result.m_nCount );
 	int index = result.m_Mapping[ key ];

--- a/src/game/client/c_baseflex.cpp
+++ b/src/game/client/c_baseflex.cpp
@@ -1865,7 +1865,7 @@ int C_BaseFlex::FlexControllerLocalToGlobal( const flexsettinghdr_t *pSettinghdr
 		}
 	}
 
-	const FS_LocalToGlobal_t& result = m_LocalToGlobal[ idx ];
+	const FS_LocalToGlobal_t &result = m_LocalToGlobal[ idx ];
 	// Validate lookup
 	Assert( result.m_nCount != 0 && key < result.m_nCount );
 	int index = result.m_Mapping[ key ];


### PR DESCRIPTION
As far as I can tell, there's no harm in doing this (as result is never mutated beyond declaration, and upon the next function call it's redeclared) and it might even result in some benefit. But mostly it's for code quality purposes.