### PR TITLE
Fixed NaN condition in beamdraw's fadeFraction

### DIFF
--- a/src/game/client/beamdraw.cpp
+++ b/src/game/client/beamdraw.cpp
@@ -319,7 +319,7 @@ void DrawSegs( int noise_divisions, float *prgNoise, const model_t* spritemodel,
 	Assert( fadeLength >= 0.0f );
 	float fadeFraction = fadeLength/ delta.Length();
 	
-	// BUGBUG: This code generates NANs when fadeFraction is zero! REVIST!
+	Assert( fadeFraction != 0 );
 	fadeFraction = clamp(fadeFraction,1.e-6f,1.f);
 
 	// Choose two vectors that are perpendicular to the beam


### PR DESCRIPTION
Sure, this might not really be the best solution, but it *does* catch any freak accidents when `fadeFraction` might be 0.
Anyone is more than welcome to suggest better ways of handling this.