### PR TITLE
No need for two if statements in first blood evaluation

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -5370,13 +5370,10 @@ void CTFGameRules::DeathNotice(CBasePlayer *pVictim, const CTakeDamageInfo &info
 			}
 
 			//first blood
-			if(!m_bFirstBlood)
+			if(!m_bFirstBlood && pVictim != pKiller) //only award first blood if it's not a suicide kill
 			{
-				if(pVictim != pKiller) //only award first blood if it's not a suicide kill
-				{
-					event->SetBool("firstblood", true);
-					m_bFirstBlood = true;
-				}
+				event->SetBool("firstblood", true);
+				m_bFirstBlood = true;
 			}
 		}
 


### PR DESCRIPTION
A recent (as of the time of writing) commit fixed the First Blood medal being awarded for suicides. However, it has an if-statement nested inside another if-statement when really the two can be merged into one with a logical AND.